### PR TITLE
Mongodb Error when user send empty [] instead of [{}]

### DIFF
--- a/lib/main/server/controllers/logController.js
+++ b/lib/main/server/controllers/logController.js
@@ -14,9 +14,9 @@ exports.getLogs = async (req, res) => {
     }
     if (query.level_json) {
       query.level_json =
-        query.level_json && query.level_json.length === 0
-          ? JSON.parse(query.level_json)
-          : [{}];
+        query.level_json && JSON.parse(query.level_json).length === 0
+          ? [{}]
+          : JSON.parse(query.level_json);
     }
     const storageConnection = getStorageConnection();
     let logs = {};

--- a/lib/main/server/controllers/logController.js
+++ b/lib/main/server/controllers/logController.js
@@ -1,19 +1,22 @@
-const Jsonapi = require('../utils/jsonapiUtil');
-const { getStorageConnection } = require('../storageConnection');
-const helpers = require('../utils/helpers');
+const Jsonapi = require("../utils/jsonapiUtil");
+const { getStorageConnection } = require("../storageConnection");
+const helpers = require("../utils/helpers");
 
 exports.getLogs = async (req, res) => {
   try {
     const query = req.query || {};
     let searchTerms;
     if (query.search_terms) {
-      searchTerms = query.search_terms.split(',');
+      searchTerms = query.search_terms.split(",");
     }
     if (query.levels) {
-      query.levels = query.levels.split(',').map(item => item.trim());
+      query.levels = query.levels.split(",").map((item) => item.trim());
     }
     if (query.level_json) {
-      query.level_json = JSON.parse(query.level_json);
+      query.level_json =
+        query.level_json && query.level_json.length === 0
+          ? JSON.parse(query.level_json)
+          : [{}];
     }
     const storageConnection = getStorageConnection();
     let logs = {};
@@ -25,19 +28,23 @@ exports.getLogs = async (req, res) => {
     if (logs && logs.items) {
       res.send(Jsonapi.Serializer.serialize(Jsonapi.UserType, logs.items));
     } else {
-      const errorData = [{
-        error: 'Bad Request',
-        message: 'invalid request'
-      }];
+      const errorData = [
+        {
+          error: "Bad Request",
+          message: "invalid request",
+        },
+      ];
       res.status(400).send({ errors: errorData });
     }
   } catch (error) {
     console.error(error);
     res.status(500).send({
-      errors: [{
-        error: 'Internal Server Error',
-        message: 'An unexpected error occurred'
-      }]
+      errors: [
+        {
+          error: "Internal Server Error",
+          message: "An unexpected error occurred",
+        },
+      ],
     });
   }
 };
@@ -45,23 +52,27 @@ exports.getLogs = async (req, res) => {
 exports.getLogsTTL = async (req, res) => {
   try {
     const storageConnection = getStorageConnection();
-    const result = await storageConnection.getConfig('logsTTL');
+    const result = await storageConnection.getConfig("logsTTL");
     if (result && result.item) {
       res.send(Jsonapi.Serializer.serialize(Jsonapi.UserType, result.item));
     } else {
-      const errorData = [{
-        error: 'Bad Request',
-        message: 'invalid request'
-      }];
+      const errorData = [
+        {
+          error: "Bad Request",
+          message: "invalid request",
+        },
+      ];
       res.status(400).send({ errors: errorData });
     }
   } catch (error) {
     console.error(error);
     res.status(500).send({
-      errors: [{
-        error: 'Internal Server Error',
-        message: 'An unexpected error occurred'
-      }]
+      errors: [
+        {
+          error: "Internal Server Error",
+          message: "An unexpected error occurred",
+        },
+      ],
     });
   }
 };
@@ -71,31 +82,37 @@ exports.updateLogsTTL = async (req, res) => {
     const { ttl } = helpers.extractAttributes(req.body);
     if (ttl) {
       const storageConnection = getStorageConnection();
-      const result = await storageConnection.setConfig('logsTTL', ttl);
+      const result = await storageConnection.setConfig("logsTTL", ttl);
       if (result && result.item) {
         await storageConnection.ensureLogsTTL();
         res.send(Jsonapi.Serializer.serialize(Jsonapi.UserType, result.item));
       } else {
-        const errorData = [{
-          error: 'Bad Request',
-          message: 'invalid request'
-        }];
+        const errorData = [
+          {
+            error: "Bad Request",
+            message: "invalid request",
+          },
+        ];
         res.status(400).send({ errors: errorData });
       }
     } else {
-      const errorData = [{
-        error: 'Bad Request',
-        message: 'invalid request'
-      }];
+      const errorData = [
+        {
+          error: "Bad Request",
+          message: "invalid request",
+        },
+      ];
       res.status(400).send({ errors: errorData });
     }
   } catch (error) {
     console.error(error);
     res.status(500).send({
-      errors: [{
-        error: 'Internal Server Error',
-        message: 'An unexpected error occurred'
-      }]
+      errors: [
+        {
+          error: "Internal Server Error",
+          message: "An unexpected error occurred",
+        },
+      ],
     });
   }
 };


### PR DESCRIPTION
When an users sends empty array in level_json [] there was a problem when contracting in errsole-mongodb

`GET /api/logs?lte_timestamp=2024-05-09T19%3A45%3A59.048Z&level_json=[] HTTP/1.1
Host: localhost:8082`

errorResponse: {
ok: 0,
errmsg: '$and/$or/$nor must be a nonempty array',
code: 2,
codeName: 'BadValue'
},
ok: 0,
code: 2,
codeName: 'BadValue',
[Symbol(errorLabels)]: Set(0) {}
}

so I have added a small filter to check if sent empty array

`      query.level_json = query.level_json && JSON.parse(query.level_json).length === 0 ? [{}]: JSON.parse(query.level_json);`

Sorry i messed up in the last PR so i closed it, i didn't parse the level_json in last one so I updated, so once again check if this works of you 