### PR TITLE
feat: Add toggle switch to sort logs (newest logs at top ON/OFF)

### DIFF
--- a/lib/web/src/actions/appActions.js
+++ b/lib/web/src/actions/appActions.js
@@ -223,6 +223,13 @@ export function clearConsoleLogs () {
   };
 }
 
+export function setLatestOnTop (latestOnTop) {
+  return {
+    type: 'SET_LATEST_ON_TOP',
+    payload: latestOnTop
+  };
+}
+
 export function getAlertUrl (callback) {
   return (dispatch) => {
     http.getAlertUrl()

--- a/lib/web/src/components/ConsoleCombinedLogs.js
+++ b/lib/web/src/components/ConsoleCombinedLogs.js
@@ -20,7 +20,8 @@ const { Panel } = Collapse;
 const mapStateToProps = (state, ownProps) => {
   return Object.assign({}, ownProps, {
     userId: state.userProfileReducer.get('userId'),
-    userProfile: state.userProfileReducer.get('userProfile')
+    userProfile: state.userProfileReducer.get('userProfile'),
+    latestOnTop: state.appReducer.get('latestOnTop')
   });
 };
 
@@ -53,6 +54,14 @@ class ConsoleCombinedLogs extends React.Component {
     }
   }
 
+  componentDidUpdate (prevProps) {
+    if (prevProps.latestOnTop !== this.props.latestOnTop) {
+      this.setState((prevState) => ({
+        combinedLogs: [...prevState.combinedLogs].reverse()
+      }));
+    }
+  }
+
   getConsoleCombinedLogs (queryRequest) {
     const self = this;
     const query = {};
@@ -79,9 +88,9 @@ class ConsoleCombinedLogs extends React.Component {
       if (query.lte_timestamp) {
         query.lte_timestamp = new Date(new Date(query.lte_timestamp).getTime() + 1000).toISOString();
       }
-      self.setState({
-        consoleCombinedLogLoading: true
-      });
+
+      self.setState({ consoleCombinedLogLoading: true });
+
       this.props.logActions.getConsoleLogs(query, function (err, data) {
         if (!err) {
           try {
@@ -93,6 +102,13 @@ class ConsoleCombinedLogs extends React.Component {
               self.setState({
                 combinedLogs: TotalLogs
               });
+              self.setState((prevState) => ({
+                combinedLogs: prevState.combinedLogs.sort((a, b) =>
+                  self.props.latestOnTop
+                    ? new Date(b.attributes.timestamp) - new Date(a.attributes.timestamp)
+                    : new Date(a.attributes.timestamp) - new Date(b.attributes.timestamp)
+                )
+              }));
               setTimeout(function () {
                 if (logs.length > 0 && TotalLogs.length === logs.length) {
                   const element = document.getElementsByClassName('selected_error_log_panel')[0];
@@ -109,9 +125,7 @@ class ConsoleCombinedLogs extends React.Component {
         } else {
           self.notificationMsg();
         }
-        self.setState({
-          consoleCombinedLogLoading: false
-        });
+        self.setState({ consoleCombinedLogLoading: false });
       });
     } else {
       message.error('Something went wrong');
@@ -124,7 +138,12 @@ class ConsoleCombinedLogs extends React.Component {
     if (isGtId) allLogs = oldLogs.concat(newLogs);
     else if (isLtId) allLogs = newLogs.concat(oldLogs);
     else allLogs = newLogs;
-    return allLogs;
+
+    return allLogs.sort((a, b) =>
+      this.props.latestOnTop
+        ? new Date(b.attributes.timestamp) - new Date(a.attributes.timestamp)
+        : new Date(a.attributes.timestamp) - new Date(b.attributes.timestamp)
+    );
   }
 
   sortLogs (latest) {
@@ -148,12 +167,15 @@ class ConsoleCombinedLogs extends React.Component {
 
   loadMoreErrors (logOrder) {
     const combinedLogs = this.state.combinedLogs || [];
-    if (combinedLogs.length > 0 && logOrder === 'latest') {
-      const logId = combinedLogs[combinedLogs.length - 1].id;
-      this.getConsoleCombinedLogs({ logOrder, logId });
+    let logId;
+
+    if (this.props.latestOnTop) {
+      logId = logOrder === 'latest' ? combinedLogs[0]?.id : combinedLogs[combinedLogs.length - 1]?.id;
+    } else {
+      logId = logOrder === 'latest' ? combinedLogs[combinedLogs.length - 1]?.id : combinedLogs[0]?.id;
     }
-    if (combinedLogs.length > 0 && logOrder === 'old') {
-      const logId = combinedLogs[0].id;
+
+    if (logId) {
       this.getConsoleCombinedLogs({ logOrder, logId });
     }
   }
@@ -303,9 +325,21 @@ class ConsoleCombinedLogs extends React.Component {
               <div className='content-box'><p className='header'>{activeKeys.length > 0 ? (<DownOutlined className='header_col_icon' onClick={this.handleAllPanel.bind(this)} />) : (<RightOutlined className='header_col_icon' onClick={this.handleAllPanel.bind(this)} />)} <span className='header_col_1'>Timestamp</span><span className='header_col_2'>Message</span></p>
                 {combinedLogs.length !== 0 &&
                   <Collapse activeKey={activeKeys} onChange={this.handlePanelChange.bind(this)}>
-                    <p className='logs_more'>There maybe older logs to load. <a onClick={this.loadMoreErrors.bind(this, 'old')}>Load More</a> </p>
-                    {renderConsoleCombinedLogs()}
-                    <p className='logs_more'>There maybe newer logs to load. <a onClick={this.loadMoreErrors.bind(this, 'latest')}>Load More</a> </p>
+                    {this.props.latestOnTop
+                      ? (
+                        <>
+                          <p className='logs_more'>There may be newer logs to load. <a onClick={() => this.loadMoreErrors('latest')}>Load More</a></p>
+                          {renderConsoleCombinedLogs()}
+                          <p className='logs_more'>There may be older logs to load. <a onClick={() => this.loadMoreErrors('old')}>Load More</a></p>
+                        </>
+                        )
+                      : (
+                        <>
+                          <p className='logs_more'>There may be older logs to load. <a onClick={() => this.loadMoreErrors('old')}>Load More</a></p>
+                          {renderConsoleCombinedLogs()}
+                          <p className='logs_more'>There may be newer logs to load. <a onClick={() => this.loadMoreErrors('latest')}>Load More</a></p>
+                        </>
+                        )}
                   </Collapse>}
                 {combinedLogs.length === 0 && <div className='ant-empty ant-empty-normal'><div className='ant-empty-image'><svg width='64' height='41' viewBox='0 0 64 41' xmlns='http://www.w3.org/2000/svg'><g transform='translate(0 1)' fill='none' fillRule='evenodd'><ellipse fill='#F5F5F5' cx='32' cy='33' rx='32' ry='7' /><g fillRule='nonzero' stroke='#D9D9D9'><path d='M55 12.76L44.854 1.258C44.367.474 43.656 0 42.907 0H21.093c-.749 0-1.46.474-1.947 1.257L9 12.761V22h46v-9.24z' /><path d='M41.613 15.931c0-1.605.994-2.93 2.227-2.931H55v18.137C55 33.26 53.68 35 52.05 35h-40.1C10.32 35 9 33.259 9 31.137V13h11.16c1.233 0 2.227 1.323 2.227 2.928v.022c0 1.605 1.005 2.901 2.237 2.901h14.752c1.232 0 2.237-1.308 2.237-2.913v-.007z' fill='#FAFAFA' /></g></g></svg></div><p className='ant-empty-description'>No Data</p></div>}
               </div>

--- a/lib/web/src/components/ConsoleLogs.js
+++ b/lib/web/src/components/ConsoleLogs.js
@@ -28,14 +28,16 @@ const { Option, OptGroup } = Select;
 /* mapStateToProps */
 const mapStateToProps = (state, ownProps) => {
   return Object.assign({}, ownProps, {
-    currentConsoleLogs: state.appReducer.get('currentConsoleLogs')
+    currentConsoleLogs: state.appReducer.get('currentConsoleLogs'),
+    latestOnTop: state.appReducer.get('latestOnTop')
   });
 };
 
 /* mapDispatchToProps */
 const mapDispatchToProps = (dispatch) => ({
   logActions: bindActionCreators(logActions, dispatch),
-  appActions: bindActionCreators(appActions, dispatch)
+  appActions: bindActionCreators(appActions, dispatch),
+  setLatestOnTop: (latestOnTop) => dispatch({ type: 'SET_LATEST_ON_TOP', payload: latestOnTop }) // ✅ New action
 });
 
 class ConsoleLogs extends React.Component {
@@ -68,8 +70,7 @@ class ConsoleLogs extends React.Component {
       errsoleLogQueryTimestamp,
       timezone: timezone || 'Local',
       autoRefresh: false,
-      isAutoRefreshing: false,
-      latestOnTop: false // Default: Old logs on top, latest logs at bottom
+      isAutoRefreshing: false
     };
   }
 
@@ -118,12 +119,13 @@ class ConsoleLogs extends React.Component {
   };
 
   handleToggleLatestOnTop = (checked) => {
+    this.props.setLatestOnTop(checked);
+
     this.setState((prevState) => {
-      const reversedLogs = [...prevState.currentConsoleLogs].reverse(); // Create a new reversed array
-      const uniqueLogs = this.removeDuplicateLogs(reversedLogs); // Ensure no duplicates
+      const reversedLogs = [...prevState.currentConsoleLogs].reverse();
+      const uniqueLogs = this.removeDuplicateLogs(reversedLogs);
 
       return {
-        latestOnTop: checked,
         currentConsoleLogs: uniqueLogs
       };
     });
@@ -360,7 +362,7 @@ class ConsoleLogs extends React.Component {
   }
 
   getCurrentConsoleLogs (query) {
-    const self = this;
+    const { latestOnTop } = this.props; // ✅ Get sort order from Redux
     const logOrder = query.logOrder;
     if (!query.logOrder) delete query.logOrder;
 
@@ -370,7 +372,7 @@ class ConsoleLogs extends React.Component {
 
     this.setState({ consoleLogLoading: true });
 
-    this.props.logActions.getConsoleLogs(query, function (err, data) {
+    this.props.logActions.getConsoleLogs(query, (err, data) => {
       if (!err) {
         try {
           let logs = data.data || [];
@@ -378,21 +380,21 @@ class ConsoleLogs extends React.Component {
 
           if (!filters || Object.keys(filters).length === 0) {
             if (logs.length === 0) {
-              self.notificationMsg('info', 'No logs to load with the applied filters.', '', 3);
+              this.notificationMsg('info', 'No logs to load with the applied filters.', '', 3);
             } else {
-              logs = self.combineLogs(logs, logOrder);
-              logs = self.removeDuplicateLogs(logs); // ✅ Ensure unique logs before setting state
+              logs = this.combineLogs(logs, logOrder);
+              logs = this.removeDuplicateLogs(logs);
 
               logs.sort((a, b) => {
                 const dateA = new Date(a.attributes.timestamp);
                 const dateB = new Date(b.attributes.timestamp);
-                return self.state.latestOnTop ? dateB - dateA : dateA - dateB;
+                return latestOnTop ? dateB - dateA : dateA - dateB;
               });
 
-              self.setState({ currentConsoleLogs: logs });
-              self.props.appActions.addConsoleLogs(logs);
+              this.setState({ currentConsoleLogs: logs });
+              this.props.appActions.addConsoleLogs(logs);
             }
-            self.setState({ oldTimestamp: null, latestTimestamp: null });
+            this.setState({ oldTimestamp: null, latestTimestamp: null });
           }
 
           if (filters && Object.keys(filters).length !== 0) {
@@ -401,28 +403,28 @@ class ConsoleLogs extends React.Component {
             if (logs.length === 0) {
               logs = [{ type: 'logs', attributes: { oldTimestamp, latestTimestamp } }];
             }
-            logs = self.combineLogs(logs, logOrder);
-            logs = self.removeDuplicateLogs(logs); // ✅ Remove duplicates after combining logs
+            logs = this.combineLogs(logs, logOrder);
+            logs = this.removeDuplicateLogs(logs);
 
             logs.sort((a, b) => {
               const dateA = new Date(a.attributes.timestamp);
               const dateB = new Date(b.attributes.timestamp);
-              return self.state.latestOnTop ? dateB - dateA : dateA - dateB;
+              return latestOnTop ? dateB - dateA : dateA - dateB;
             });
 
-            self.setState({ currentConsoleLogs: logs });
-            self.props.appActions.addConsoleLogs(logs);
-            self.setState({ oldTimestamp, latestTimestamp });
+            this.setState({ currentConsoleLogs: logs });
+            this.props.appActions.addConsoleLogs(logs);
+            this.setState({ oldTimestamp, latestTimestamp });
           }
         } catch (e) {
           console.error(e);
-          self.notificationMsg();
+          this.notificationMsg();
         }
       } else {
-        self.notificationMsg();
+        this.notificationMsg();
       }
 
-      self.setState({ consoleLogLoading: false });
+      this.setState({ consoleLogLoading: false });
     });
   }
 
@@ -506,17 +508,12 @@ class ConsoleLogs extends React.Component {
   }
 
   loadMoreErrors (logOrder) {
+    const { latestOnTop } = this.props; // ✅ Get sort order from Redux
     const currentConsoleLogs = this.state.currentConsoleLogs || [];
     let logId, datetime;
     if (logOrder === 'latest') {
       logId = currentConsoleLogs.length > 0 ? currentConsoleLogs[currentConsoleLogs.length - 1].id : null;
-      if (this.state.latestTimestamp) {
-        if (logId) {
-          datetime = currentConsoleLogs[currentConsoleLogs.length - 1].attributes.timestamp;
-        } else {
-          datetime = this.state.latestTimestamp;
-        }
-      }
+      datetime = logId ? currentConsoleLogs[currentConsoleLogs.length - 1].attributes.timestamp : this.state.latestTimestamp;
     } else if (logOrder === 'old') {
       logId = currentConsoleLogs.length > 0 ? currentConsoleLogs[0].id : null;
       datetime = logId ? currentConsoleLogs[0].attributes.timestamp : this.state.oldTimestamp;
@@ -525,9 +522,17 @@ class ConsoleLogs extends React.Component {
     this.getConsoleLogs({ logOrder, logId, datetime }, 'loadMore', (err, newLogs) => {
       if (!err && newLogs.length > 0) {
         this.setState((prevState) => {
-          const mergedLogs = logOrder === 'latest'
-            ? [...prevState.currentConsoleLogs, ...newLogs] // Append latest logs
-            : [...newLogs, ...prevState.currentConsoleLogs]; // Prepend old logs
+          let mergedLogs;
+
+          if (latestOnTop) {
+            mergedLogs = logOrder === 'latest'
+              ? [...newLogs, ...prevState.currentConsoleLogs] // Insert new logs at the top
+              : [...prevState.currentConsoleLogs, ...newLogs]; // Insert old logs at the bottom
+          } else {
+            mergedLogs = logOrder === 'latest'
+              ? [...prevState.currentConsoleLogs, ...newLogs] // Append latest logs at the bottom
+              : [...newLogs, ...prevState.currentConsoleLogs]; // Prepend old logs at the top
+          }
 
           return {
             currentConsoleLogs: this.removeDuplicateLogs(mergedLogs) // ✅ Ensure uniqueness
@@ -999,7 +1004,7 @@ class ConsoleLogs extends React.Component {
                 </p>
                 {currentConsoleLogs.length !== 0 &&
                   <Collapse activeKey={activeKeys} onChange={this.handlePanelChange.bind(this)}>
-                    {this.state.latestOnTop
+                    {this.props.latestOnTop
                       ? (
                         <>
                           <p className='logs_more'>There may be newer logs to load. <a onClick={() => this.loadMoreErrors('latest')}>Load More</a> </p>

--- a/lib/web/src/components/ConsoleLogs.js
+++ b/lib/web/src/components/ConsoleLogs.js
@@ -68,7 +68,8 @@ class ConsoleLogs extends React.Component {
       errsoleLogQueryTimestamp,
       timezone: timezone || 'Local',
       autoRefresh: false,
-      isAutoRefreshing: false
+      isAutoRefreshing: false,
+      latestOnTop: false // Default: Old logs on top, latest logs at bottom
     };
   }
 
@@ -114,6 +115,36 @@ class ConsoleLogs extends React.Component {
   stopAutoRefresh = () => {
     clearInterval(this.autoRefreshInterval);
     this.setState({ isAutoRefreshing: false });
+  };
+
+  toggleLatestOnTop = (checked) => {
+    this.setState((prevState) => {
+      const reversedLogs = [...prevState.currentConsoleLogs].reverse(); // Create a new reversed array
+      const uniqueLogs = this.removeDuplicateLogs(reversedLogs); // Ensure no duplicates
+
+      return {
+        latestOnTop: checked,
+        currentConsoleLogs: uniqueLogs
+      };
+    });
+  };
+
+  removeDuplicateLogs (logs) {
+    const uniqueLogs = [];
+    const seen = new Set();
+    logs.forEach((log) => {
+      if (!seen.has(log.id)) {
+        seen.add(log.id);
+        uniqueLogs.push(log);
+      }
+    });
+    return uniqueLogs;
+  }
+
+  sortLogsByToggle = () => {
+    this.setState((prevState) => ({
+      currentConsoleLogs: [...prevState.currentConsoleLogs].reverse()
+    }));
   };
 
   getHostnames () {
@@ -337,62 +368,51 @@ class ConsoleLogs extends React.Component {
       query.lte_timestamp = new Date(new Date(query.lte_timestamp).getTime() + 1000).toISOString();
     }
 
-    this.setState({
-      consoleLogLoading: true
-    });
+    this.setState({ consoleLogLoading: true });
+
     this.props.logActions.getConsoleLogs(query, function (err, data) {
       if (!err) {
         try {
           let logs = data.data || [];
           const filters = data.meta ? data.meta.filters : {};
-          // no search
+
           if (!filters || Object.keys(filters).length === 0) {
             if (logs.length === 0) {
-              self.notificationMsg('info', 'No logs to load with the applied filters. Try adjusting the filters or search terms and search again.', '', 3);
-            } else if (logs.length > 0) {
+              self.notificationMsg('info', 'No logs to load with the applied filters.', '', 3);
+            } else {
               logs = self.combineLogs(logs, logOrder);
-              self.setState({
-                currentConsoleLogs: logs
+              logs = self.removeDuplicateLogs(logs); // ✅ Ensure unique logs before setting state
+
+              logs.sort((a, b) => {
+                const dateA = new Date(a.attributes.timestamp);
+                const dateB = new Date(b.attributes.timestamp);
+                return self.state.latestOnTop ? dateB - dateA : dateA - dateB;
               });
+
+              self.setState({ currentConsoleLogs: logs });
               self.props.appActions.addConsoleLogs(logs);
             }
-            self.setState({
-              oldTimestamp: null,
-              latestTimestamp: null
-            });
+            self.setState({ oldTimestamp: null, latestTimestamp: null });
           }
-          // handle search
+
           if (filters && Object.keys(filters).length !== 0) {
             const oldTimestamp = filters.gte_timestamp;
             const latestTimestamp = filters.lte_timestamp;
             if (logs.length === 0) {
-              logs = [{
-                type: 'logs',
-                attributes: {
-                  oldTimestamp,
-                  latestTimestamp
-                }
-              }];
+              logs = [{ type: 'logs', attributes: { oldTimestamp, latestTimestamp } }];
             }
             logs = self.combineLogs(logs, logOrder);
-            self.setState({
-              currentConsoleLogs: logs
+            logs = self.removeDuplicateLogs(logs); // ✅ Remove duplicates after combining logs
+
+            logs.sort((a, b) => {
+              const dateA = new Date(a.attributes.timestamp);
+              const dateB = new Date(b.attributes.timestamp);
+              return self.state.latestOnTop ? dateB - dateA : dateA - dateB;
             });
+
+            self.setState({ currentConsoleLogs: logs });
             self.props.appActions.addConsoleLogs(logs);
-            if (!logOrder || (!self.state.oldTimestamp && !self.state.latestTimestamp)) {
-              self.setState({
-                oldTimestamp,
-                latestTimestamp
-              });
-            } else if (logOrder === 'old') {
-              self.setState({
-                oldTimestamp
-              });
-            } else if (logOrder === 'latest') {
-              self.setState({
-                latestTimestamp
-              });
-            }
+            self.setState({ oldTimestamp, latestTimestamp });
           }
         } catch (e) {
           console.error(e);
@@ -401,9 +421,8 @@ class ConsoleLogs extends React.Component {
       } else {
         self.notificationMsg();
       }
-      self.setState({
-        consoleLogLoading: false
-      });
+
+      self.setState({ consoleLogLoading: false });
     });
   }
 
@@ -455,6 +474,9 @@ class ConsoleLogs extends React.Component {
     if (logOrder === 'latest') allLogs = oldLogs.concat(newLogs);
     else if (logOrder === 'old') allLogs = newLogs.concat(oldLogs);
     else allLogs = newLogs;
+    if (this.state.latestOnTop) {
+      allLogs.reverse();
+    }
     return allLogs;
   }
 
@@ -497,15 +519,22 @@ class ConsoleLogs extends React.Component {
       }
     } else if (logOrder === 'old') {
       logId = currentConsoleLogs.length > 0 ? currentConsoleLogs[0].id : null;
-      if (this.state.oldTimestamp) {
-        if (logId) {
-          datetime = currentConsoleLogs[0].attributes.timestamp;
-        } else {
-          datetime = this.state.oldTimestamp;
-        }
-      }
+      datetime = logId ? currentConsoleLogs[0].attributes.timestamp : this.state.oldTimestamp;
     }
-    this.getConsoleLogs({ logOrder, logId, datetime }, 'loadMore');
+
+    this.getConsoleLogs({ logOrder, logId, datetime }, 'loadMore', (err, newLogs) => {
+      if (!err && newLogs.length > 0) {
+        this.setState((prevState) => {
+          const mergedLogs = logOrder === 'latest'
+            ? [...prevState.currentConsoleLogs, ...newLogs] // Append latest logs
+            : [...newLogs, ...prevState.currentConsoleLogs]; // Prepend old logs
+
+          return {
+            currentConsoleLogs: this.removeDuplicateLogs(mergedLogs) // ✅ Ensure uniqueness
+          };
+        });
+      }
+    });
   }
 
   sortLogs (latest) {
@@ -932,6 +961,9 @@ class ConsoleLogs extends React.Component {
                     <div className='filter float-r log-btn-reset'>
                       <span className='Timezone'>Timezone <Switch checkedChildren='Local' unCheckedChildren='UTC' checked={timezone === 'Local'} onChange={this.changeTimezone.bind(this)} /></span>
                       <span className='Auto-Refresh'>
+                        Logs Order <Switch checkedChildren='Newest First' unCheckedChildren='Oldest First' checked={this.state.latestOnTop} onChange={(checked) => this.setState({ latestOnTop: checked })} />
+                      </span>
+                      <span className='Auto-Refresh'>
                         Auto Refresh <Switch
                           checkedChildren='On'
                           unCheckedChildren='Off'
@@ -962,9 +994,21 @@ class ConsoleLogs extends React.Component {
                 </p>
                 {currentConsoleLogs.length !== 0 &&
                   <Collapse activeKey={activeKeys} onChange={this.handlePanelChange.bind(this)}>
-                    <p className='logs_more'>There may be older logs to load. <a onClick={this.loadMoreErrors.bind(this, 'old')}>Load More</a> </p>
-                    {renderConsoleLogs()}
-                    <p className='logs_more'>There may be newer logs to load. <a onClick={this.loadMoreErrors.bind(this, 'latest')}>Load More</a> </p>
+                    {this.state.latestOnTop
+                      ? (
+                        <>
+                          <p className='logs_more'>There may be newer logs to load. <a onClick={() => this.loadMoreErrors('latest')}>Load More</a> </p>
+                          {renderConsoleLogs()}
+                          <p className='logs_more'>There may be older logs to load. <a onClick={() => this.loadMoreErrors('old')}>Load More</a> </p>
+                        </>
+                        )
+                      : (
+                        <>
+                          <p className='logs_more'>There may be older logs to load. <a onClick={() => this.loadMoreErrors('old')}>Load More</a> </p>
+                          {renderConsoleLogs()}
+                          <p className='logs_more'>There may be newer logs to load. <a onClick={() => this.loadMoreErrors('latest')}>Load More</a> </p>
+                        </>
+                        )}
                   </Collapse>}
                 {currentConsoleLogs.length === 0 && <div className='ant-empty ant-empty-normal'><div className='ant-empty-image'><svg width='64' height='41' viewBox='0 0 64 41' xmlns='http://www.w3.org/2000/svg'><g transform='translate(0 1)' fill='none' fillRule='evenodd'><ellipse fill='#F5F5F5' cx='32' cy='33' rx='32' ry='7' /><g fillRule='nonzero' stroke='#D9D9D9'><path d='M55 12.76L44.854 1.258C44.367.474 43.656 0 42.907 0H21.093c-.749 0-1.46.474-1.947 1.257L9 12.761V22h46v-9.24z' /><path d='M41.613 15.931c0-1.605.994-2.93 2.227-2.931H55v18.137C55 33.26 53.68 35 52.05 35h-40.1C10.32 35 9 33.259 9 31.137V13h11.16c1.233 0 2.227 1.323 2.227 2.928v.022c0 1.605 1.005 2.901 2.237 2.901h14.752c1.232 0 2.237-1.308 2.237-2.913v-.007z' fill='#FAFAFA' /></g></g></svg></div><p className='ant-empty-description'>No Data</p></div>}
               </div>

--- a/lib/web/src/components/ConsoleLogs.js
+++ b/lib/web/src/components/ConsoleLogs.js
@@ -117,7 +117,7 @@ class ConsoleLogs extends React.Component {
     this.setState({ isAutoRefreshing: false });
   };
 
-  toggleLatestOnTop = (checked) => {
+  handleToggleLatestOnTop = (checked) => {
     this.setState((prevState) => {
       const reversedLogs = [...prevState.currentConsoleLogs].reverse(); // Create a new reversed array
       const uniqueLogs = this.removeDuplicateLogs(reversedLogs); // Ensure no duplicates
@@ -961,7 +961,12 @@ class ConsoleLogs extends React.Component {
                     <div className='filter float-r log-btn-reset'>
                       <span className='Timezone'>Timezone <Switch checkedChildren='Local' unCheckedChildren='UTC' checked={timezone === 'Local'} onChange={this.changeTimezone.bind(this)} /></span>
                       <span className='Auto-Refresh'>
-                        Logs Order <Switch checkedChildren='Newest First' unCheckedChildren='Oldest First' checked={this.state.latestOnTop} onChange={(checked) => this.setState({ latestOnTop: checked })} />
+                        Logs Order <Switch
+                          checkedChildren='Newest First'
+                          unCheckedChildren='Oldest First'
+                          checked={this.state.latestOnTop}
+                          onChange={this.handleToggleLatestOnTop}
+                                   />
                       </span>
                       <span className='Auto-Refresh'>
                         Auto Refresh <Switch

--- a/lib/web/src/components/DataRetention.js
+++ b/lib/web/src/components/DataRetention.js
@@ -105,7 +105,7 @@ class DataRetention extends React.Component {
 
   render () {
     const logsTTLDays = this.state.logsTTLDays || null;
-    const loadingStatus = this.state.loadingStatus || null;
+    const loadingStatus = this.state.loadingStatus || false;
 
     return (
       <>

--- a/lib/web/src/reducers/appReducer.js
+++ b/lib/web/src/reducers/appReducer.js
@@ -1,7 +1,8 @@
 import Immutable from 'immutable';
 
 const initialState = Immutable.Map({
-  currentConsoleLogs: []
+  currentConsoleLogs: [],
+  latestOnTop: false
 });
 
 function appReducer (state = initialState, action) {
@@ -14,6 +15,9 @@ function appReducer (state = initialState, action) {
     case 'CLEAR_CONSOLE_LOGS': {
       state = state.set('currentConsoleLogs', []);
       break;
+    }
+    case 'SET_LATEST_ON_TOP': {
+      return state.set('latestOnTop', action.payload);
     }
     case 'RESET_USER_STATE': {
       state = initialState;


### PR DESCRIPTION
This PR introduces a toggle switch that allows users to dynamically change the sort order of logs. When the switch is ON, logs are displayed in descending order (newest first). When OFF, logs are shown in ascending order (oldest first).

**Changes**

- Implemented a toggle switch in the UI to control log sorting.
- Updated the log retrieval logic to apply sorting based on the toggle state.
- Ensured the toggle state is persisted and properly reflected when switching views.

**Impact**

- Provides flexibility for users to view logs in their preferred order.
- Enhances usability by allowing quick access to recent logs when needed.

**Testing**

- Verified that switching ON displays logs in descending order.
- Verified that switching OFF displays logs in ascending order.
- Ensured state updates correctly across sessions.