### PR TITLE
feat(ui): add informational message to DatePicker for log retrieval behavior

### DIFF
--- a/lib/web/src/components/ConsoleLogs.js
+++ b/lib/web/src/components/ConsoleLogs.js
@@ -909,7 +909,13 @@ class ConsoleLogs extends React.Component {
                       ? dayjs(`${searchDate} ${searchTime}`, 'YYYY-MM-DD HH:mm:ss')
                       : null
                   }
+                  renderExtraFooter={() => (
+                    <div style={{ textAlign: 'center', fontSize: '15px', color: '#0D0D0D' }}>
+                      Logs generated before this timestamp will be displayed.
+                    </div>
+                  )}
                 />
+
               </div>
               <div className='button-row'>
                 <div className='filter float-l log-btn-apply'>


### PR DESCRIPTION
### Pull Request Description
This update adds a message above the "Now" button in the DatePicker panel, informing users that logs generated before the selected timestamp will be displayed.

### Changes:

- Implemented renderExtraFooter in Ant Design DatePicker.
- Message added: "Logs generated before this timestamp will be displayed."
- Improves user understanding of log retrieval behavior.