### PR TITLE
feat: Add toggle switch to sort logs (newest logs at top ON/OFF)

### DIFF
--- a/examples/index.js
+++ b/examples/index.js
@@ -8,7 +8,7 @@ const errsole = require('../lib/errsole.js');
 const ErrsoleSQLite = require('errsole-sqlite');
 
 errsole.initialize({
-  storage: new ErrsoleSQLite('/tmp/logssss.sqlite')
+  storage: new ErrsoleSQLite('/tmp/logs.sqlite')
 });
 
 const express = require('express');
@@ -39,12 +39,12 @@ function generateRandomLine (wordCount) {
 
 const meta = { user: { name: 'John Doe', age: 35, email: 'johndoe@example.com', address: { street: '123 Main St', city: 'Springfield', state: 'IL', zipCode: '62701' }, preferences: { theme: 'dark', notifications: true } }, friends: [{ name: 'Jane Smith', contact: { email: 'jane.smith@example.com', phone: '123-456-7890' }, social: [{ platform: 'Twitter', handle: '@janesmith' }, { platform: 'LinkedIn', handle: 'linkedin.com/in/janesmith' }] }, { name: 'Michael Johnson', contact: { email: 'michael.johnson@example.com', phone: '987-654-3210' }, social: [{ platform: 'Twitter', handle: '@michaeljohnson' }, { platform: 'Instagram', handle: '@mikejohn' }] }], company: { name: 'TechCorp', address: { street: '456 Tech Blvd', city: 'Metropolis', state: 'NY', zipCode: '10001' }, departments: [{ name: 'Engineering', employees: [{ name: 'Alice Cooper', role: 'Lead Engineer' }, { name: 'Bob Brown', role: 'Software Engineer' }] }, { name: 'Marketing', employees: [{ name: 'Carol White', role: 'Marketing Manager' }, { name: 'David Green', role: 'Content Strategist' }] }] }, hobbies: [{ name: 'Photography', level: 'Intermediate' }, { name: 'Cycling', level: 'Beginner' }, { name: 'Cooking', level: 'Advanced' }] };
 
-// setInterval(function () {
-//   const time = Math.floor(Math.random() * (4000 - 700 + 1) + 1300);
-//   errsole.log(generateRandomLine(50) + ' ' + time);
-//   errsole.error(generateRandomLine(50) + ' ' + time);
-//   errsole.meta(meta).error(generateRandomLine(50) + ' ' + time);
-// }, 5000);
+setInterval(function () {
+  const time = Math.floor(Math.random() * (4000 - 700 + 1) + 1300);
+  errsole.log(generateRandomLine(50) + ' ' + time);
+  errsole.error(generateRandomLine(50) + ' ' + time);
+  errsole.meta(meta).error(generateRandomLine(50) + ' ' + time);
+}, 5000);
 
 const port = 9000;
 

--- a/examples/index.js
+++ b/examples/index.js
@@ -8,7 +8,7 @@ const errsole = require('../lib/errsole.js');
 const ErrsoleSQLite = require('errsole-sqlite');
 
 errsole.initialize({
-  storage: new ErrsoleSQLite('/tmp/logs.sqlite')
+  storage: new ErrsoleSQLite('/tmp/logssss.sqlite')
 });
 
 const express = require('express');
@@ -39,12 +39,12 @@ function generateRandomLine (wordCount) {
 
 const meta = { user: { name: 'John Doe', age: 35, email: 'johndoe@example.com', address: { street: '123 Main St', city: 'Springfield', state: 'IL', zipCode: '62701' }, preferences: { theme: 'dark', notifications: true } }, friends: [{ name: 'Jane Smith', contact: { email: 'jane.smith@example.com', phone: '123-456-7890' }, social: [{ platform: 'Twitter', handle: '@janesmith' }, { platform: 'LinkedIn', handle: 'linkedin.com/in/janesmith' }] }, { name: 'Michael Johnson', contact: { email: 'michael.johnson@example.com', phone: '987-654-3210' }, social: [{ platform: 'Twitter', handle: '@michaeljohnson' }, { platform: 'Instagram', handle: '@mikejohn' }] }], company: { name: 'TechCorp', address: { street: '456 Tech Blvd', city: 'Metropolis', state: 'NY', zipCode: '10001' }, departments: [{ name: 'Engineering', employees: [{ name: 'Alice Cooper', role: 'Lead Engineer' }, { name: 'Bob Brown', role: 'Software Engineer' }] }, { name: 'Marketing', employees: [{ name: 'Carol White', role: 'Marketing Manager' }, { name: 'David Green', role: 'Content Strategist' }] }] }, hobbies: [{ name: 'Photography', level: 'Intermediate' }, { name: 'Cycling', level: 'Beginner' }, { name: 'Cooking', level: 'Advanced' }] };
 
-setInterval(function () {
-  const time = Math.floor(Math.random() * (4000 - 700 + 1) + 1300);
-  errsole.log(generateRandomLine(50) + ' ' + time);
-  errsole.error(generateRandomLine(50) + ' ' + time);
-  errsole.meta(meta).error(generateRandomLine(50) + ' ' + time);
-}, 5000);
+// setInterval(function () {
+//   const time = Math.floor(Math.random() * (4000 - 700 + 1) + 1300);
+//   errsole.log(generateRandomLine(50) + ' ' + time);
+//   errsole.error(generateRandomLine(50) + ' ' + time);
+//   errsole.meta(meta).error(generateRandomLine(50) + ' ' + time);
+// }, 5000);
 
 const port = 9000;
 

--- a/lib/web/assets/css/app.css
+++ b/lib/web/assets/css/app.css
@@ -895,10 +895,10 @@ body {
   .divide-container{
     display: flex;
     justify-content: center;
-    align-items: center;
   }
 
   .hide-message .ant-switch {
+    min-width: 110px !important;
     transform: scale(0.8); 
   }
 
@@ -906,7 +906,7 @@ body {
     font-size: 13px; 
   }
   .Auto-Refresh{
-    margin-left: 5px !important;
+    margin-left: 19px !important;
   }
 } 
 

--- a/lib/web/assets/css/app.css
+++ b/lib/web/assets/css/app.css
@@ -316,6 +316,9 @@ body {
   float: right;
   padding-right: 50px;
 }
+.github-star-button p{
+  margin: inherit;
+}
 
 .github-star-button button {
   background: whitesmoke;
@@ -891,11 +894,14 @@ body {
   }
   .divide-container{
     display: flex;
+    justify-content: center;
+    align-items: center;
   }
 
   .hide-message .ant-switch {
     transform: scale(0.8); 
   }
+
   .hide-message span {
     font-size: 13px; 
   }

--- a/lib/web/src/actions/appActions.js
+++ b/lib/web/src/actions/appActions.js
@@ -223,6 +223,13 @@ export function clearConsoleLogs () {
   };
 }
 
+export function setLatestOnTop (latestOnTop) {
+  return {
+    type: 'SET_LATEST_ON_TOP',
+    payload: latestOnTop
+  };
+}
+
 export function getAlertUrl (callback) {
   return (dispatch) => {
     http.getAlertUrl()

--- a/lib/web/src/components/ConsoleCombinedLogs.js
+++ b/lib/web/src/components/ConsoleCombinedLogs.js
@@ -20,8 +20,7 @@ const { Panel } = Collapse;
 const mapStateToProps = (state, ownProps) => {
   return Object.assign({}, ownProps, {
     userId: state.userProfileReducer.get('userId'),
-    userProfile: state.userProfileReducer.get('userProfile'),
-    latestOnTop: state.appReducer.get('latestOnTop')
+    userProfile: state.userProfileReducer.get('userProfile')
   });
 };
 
@@ -36,12 +35,14 @@ class ConsoleCombinedLogs extends React.Component {
     const errorLogId = this.props.errorLogId;
     const errorLogHostname = this.props.errorLogHostname;
     const timezone = cookies.get('errsole-timezone-preference');
+    const latestOnTop = cookies.get('errsole-latest-on-top') || 'Oldest First';
 
     this.state = {
       errorLogTimestamp,
       errorLogId,
       consoleCombinedLogLoading: false,
       combinedLogs: [],
+      latestOnTop,
       timezone,
       errorLogHostname
     };
@@ -54,8 +55,8 @@ class ConsoleCombinedLogs extends React.Component {
     }
   }
 
-  componentDidUpdate (prevProps) {
-    if (prevProps.latestOnTop !== this.props.latestOnTop) {
+  componentDidUpdate (prevProps, prevState) {
+    if (prevState.latestOnTop !== this.state.latestOnTop) { // ✅ Use state instead of props
       this.setState((prevState) => ({
         combinedLogs: [...prevState.combinedLogs].reverse()
       }));
@@ -65,14 +66,18 @@ class ConsoleCombinedLogs extends React.Component {
   getConsoleCombinedLogs (queryRequest) {
     const self = this;
     const query = {};
+
+    // Fetch latest sorting order from the cookie
+    const latestOnTopFromCookie = cookies.get('errsole-latest-on-top') || 'Oldest First';
+
     if (queryRequest && queryRequest.logOrder) {
-      //
       if (!queryRequest || (queryRequest && !queryRequest.logId)) {
         if (queryRequest && queryRequest.datetime) {
           query.lte_timestamp = new Date(queryRequest.datetime).toISOString();
         }
       }
-      // get latest logs
+
+      // Get latest logs
       if (queryRequest && queryRequest.logId) {
         if (queryRequest.logOrder === 'old') {
           query.lt_id = queryRequest.logId;
@@ -81,6 +86,7 @@ class ConsoleCombinedLogs extends React.Component {
           query.gt_id = queryRequest.logId;
         }
       }
+
       const errorLogHostname = this.state.errorLogHostname;
       if (errorLogHostname) {
         query.hostname = errorLogHostname;
@@ -99,16 +105,19 @@ class ConsoleCombinedLogs extends React.Component {
               self.notificationMsg('info', 'No logs to load');
             } else {
               const TotalLogs = self.combineLogs(logs, query.gt_id, query.lt_id);
+
+              // Sort logs using the latest toggle state
+              const sortedLogs = TotalLogs.sort((a, b) =>
+                latestOnTopFromCookie === 'Newest First'
+                  ? new Date(b.attributes.timestamp) - new Date(a.attributes.timestamp)
+                  : new Date(a.attributes.timestamp) - new Date(b.attributes.timestamp)
+              );
+
               self.setState({
-                combinedLogs: TotalLogs
+                combinedLogs: sortedLogs,
+                latestOnTop: latestOnTopFromCookie // Ensure state updates too
               });
-              self.setState((prevState) => ({
-                combinedLogs: prevState.combinedLogs.sort((a, b) =>
-                  self.props.latestOnTop
-                    ? new Date(b.attributes.timestamp) - new Date(a.attributes.timestamp)
-                    : new Date(a.attributes.timestamp) - new Date(b.attributes.timestamp)
-                )
-              }));
+
               setTimeout(function () {
                 if (logs.length > 0 && TotalLogs.length === logs.length) {
                   const element = document.getElementsByClassName('selected_error_log_panel')[0];
@@ -135,12 +144,16 @@ class ConsoleCombinedLogs extends React.Component {
   combineLogs (newLogs, isGtId, isLtId) {
     const oldLogs = this.state.combinedLogs || [];
     let allLogs;
+
     if (isGtId) allLogs = oldLogs.concat(newLogs);
     else if (isLtId) allLogs = newLogs.concat(oldLogs);
     else allLogs = newLogs;
 
+    // Read sorting order from the cookie every time
+    const latestOnTopFromCookie = cookies.get('errsole-latest-on-top') || 'Oldest First';
+
     return allLogs.sort((a, b) =>
-      this.props.latestOnTop
+      latestOnTopFromCookie === 'Newest First'
         ? new Date(b.attributes.timestamp) - new Date(a.attributes.timestamp)
         : new Date(a.attributes.timestamp) - new Date(b.attributes.timestamp)
     );
@@ -169,7 +182,10 @@ class ConsoleCombinedLogs extends React.Component {
     const combinedLogs = this.state.combinedLogs || [];
     let logId;
 
-    if (this.props.latestOnTop) {
+    // ✅ Read latestOnTop directly from the cookie
+    const latestOnTopFromCookie = cookies.get('errsole-latest-on-top') || 'Oldest First';
+
+    if (latestOnTopFromCookie === 'Newest First') {
       logId = logOrder === 'latest' ? combinedLogs[0]?.id : combinedLogs[combinedLogs.length - 1]?.id;
     } else {
       logId = logOrder === 'latest' ? combinedLogs[combinedLogs.length - 1]?.id : combinedLogs[0]?.id;
@@ -325,7 +341,7 @@ class ConsoleCombinedLogs extends React.Component {
               <div className='content-box'><p className='header'>{activeKeys.length > 0 ? (<DownOutlined className='header_col_icon' onClick={this.handleAllPanel.bind(this)} />) : (<RightOutlined className='header_col_icon' onClick={this.handleAllPanel.bind(this)} />)} <span className='header_col_1'>Timestamp</span><span className='header_col_2'>Message</span></p>
                 {combinedLogs.length !== 0 &&
                   <Collapse activeKey={activeKeys} onChange={this.handlePanelChange.bind(this)}>
-                    {this.props.latestOnTop
+                    {this.state.latestOnTop === 'Newest First' // ✅ Use state instead of props
                       ? (
                         <>
                           <p className='logs_more'>There may be newer logs to load. <a onClick={() => this.loadMoreErrors('latest')}>Load More</a></p>

--- a/lib/web/src/components/ConsoleCombinedLogs.js
+++ b/lib/web/src/components/ConsoleCombinedLogs.js
@@ -20,7 +20,8 @@ const { Panel } = Collapse;
 const mapStateToProps = (state, ownProps) => {
   return Object.assign({}, ownProps, {
     userId: state.userProfileReducer.get('userId'),
-    userProfile: state.userProfileReducer.get('userProfile')
+    userProfile: state.userProfileReducer.get('userProfile'),
+    latestOnTop: state.appReducer.get('latestOnTop')
   });
 };
 
@@ -53,6 +54,14 @@ class ConsoleCombinedLogs extends React.Component {
     }
   }
 
+  componentDidUpdate (prevProps) {
+    if (prevProps.latestOnTop !== this.props.latestOnTop) {
+      this.setState((prevState) => ({
+        combinedLogs: [...prevState.combinedLogs].reverse()
+      }));
+    }
+  }
+
   getConsoleCombinedLogs (queryRequest) {
     const self = this;
     const query = {};
@@ -79,9 +88,9 @@ class ConsoleCombinedLogs extends React.Component {
       if (query.lte_timestamp) {
         query.lte_timestamp = new Date(new Date(query.lte_timestamp).getTime() + 1000).toISOString();
       }
-      self.setState({
-        consoleCombinedLogLoading: true
-      });
+
+      self.setState({ consoleCombinedLogLoading: true });
+
       this.props.logActions.getConsoleLogs(query, function (err, data) {
         if (!err) {
           try {
@@ -93,6 +102,13 @@ class ConsoleCombinedLogs extends React.Component {
               self.setState({
                 combinedLogs: TotalLogs
               });
+              self.setState((prevState) => ({
+                combinedLogs: prevState.combinedLogs.sort((a, b) =>
+                  self.props.latestOnTop
+                    ? new Date(b.attributes.timestamp) - new Date(a.attributes.timestamp)
+                    : new Date(a.attributes.timestamp) - new Date(b.attributes.timestamp)
+                )
+              }));
               setTimeout(function () {
                 if (logs.length > 0 && TotalLogs.length === logs.length) {
                   const element = document.getElementsByClassName('selected_error_log_panel')[0];
@@ -109,9 +125,7 @@ class ConsoleCombinedLogs extends React.Component {
         } else {
           self.notificationMsg();
         }
-        self.setState({
-          consoleCombinedLogLoading: false
-        });
+        self.setState({ consoleCombinedLogLoading: false });
       });
     } else {
       message.error('Something went wrong');
@@ -124,7 +138,12 @@ class ConsoleCombinedLogs extends React.Component {
     if (isGtId) allLogs = oldLogs.concat(newLogs);
     else if (isLtId) allLogs = newLogs.concat(oldLogs);
     else allLogs = newLogs;
-    return allLogs;
+
+    return allLogs.sort((a, b) =>
+      this.props.latestOnTop
+        ? new Date(b.attributes.timestamp) - new Date(a.attributes.timestamp)
+        : new Date(a.attributes.timestamp) - new Date(b.attributes.timestamp)
+    );
   }
 
   sortLogs (latest) {
@@ -148,12 +167,15 @@ class ConsoleCombinedLogs extends React.Component {
 
   loadMoreErrors (logOrder) {
     const combinedLogs = this.state.combinedLogs || [];
-    if (combinedLogs.length > 0 && logOrder === 'latest') {
-      const logId = combinedLogs[combinedLogs.length - 1].id;
-      this.getConsoleCombinedLogs({ logOrder, logId });
+    let logId;
+
+    if (this.props.latestOnTop) {
+      logId = logOrder === 'latest' ? combinedLogs[0]?.id : combinedLogs[combinedLogs.length - 1]?.id;
+    } else {
+      logId = logOrder === 'latest' ? combinedLogs[combinedLogs.length - 1]?.id : combinedLogs[0]?.id;
     }
-    if (combinedLogs.length > 0 && logOrder === 'old') {
-      const logId = combinedLogs[0].id;
+
+    if (logId) {
       this.getConsoleCombinedLogs({ logOrder, logId });
     }
   }
@@ -303,9 +325,21 @@ class ConsoleCombinedLogs extends React.Component {
               <div className='content-box'><p className='header'>{activeKeys.length > 0 ? (<DownOutlined className='header_col_icon' onClick={this.handleAllPanel.bind(this)} />) : (<RightOutlined className='header_col_icon' onClick={this.handleAllPanel.bind(this)} />)} <span className='header_col_1'>Timestamp</span><span className='header_col_2'>Message</span></p>
                 {combinedLogs.length !== 0 &&
                   <Collapse activeKey={activeKeys} onChange={this.handlePanelChange.bind(this)}>
-                    <p className='logs_more'>There maybe older logs to load. <a onClick={this.loadMoreErrors.bind(this, 'old')}>Load More</a> </p>
-                    {renderConsoleCombinedLogs()}
-                    <p className='logs_more'>There maybe newer logs to load. <a onClick={this.loadMoreErrors.bind(this, 'latest')}>Load More</a> </p>
+                    {this.props.latestOnTop
+                      ? (
+                        <>
+                          <p className='logs_more'>There may be newer logs to load. <a onClick={() => this.loadMoreErrors('latest')}>Load More</a></p>
+                          {renderConsoleCombinedLogs()}
+                          <p className='logs_more'>There may be older logs to load. <a onClick={() => this.loadMoreErrors('old')}>Load More</a></p>
+                        </>
+                        )
+                      : (
+                        <>
+                          <p className='logs_more'>There may be older logs to load. <a onClick={() => this.loadMoreErrors('old')}>Load More</a></p>
+                          {renderConsoleCombinedLogs()}
+                          <p className='logs_more'>There may be newer logs to load. <a onClick={() => this.loadMoreErrors('latest')}>Load More</a></p>
+                        </>
+                        )}
                   </Collapse>}
                 {combinedLogs.length === 0 && <div className='ant-empty ant-empty-normal'><div className='ant-empty-image'><svg width='64' height='41' viewBox='0 0 64 41' xmlns='http://www.w3.org/2000/svg'><g transform='translate(0 1)' fill='none' fillRule='evenodd'><ellipse fill='#F5F5F5' cx='32' cy='33' rx='32' ry='7' /><g fillRule='nonzero' stroke='#D9D9D9'><path d='M55 12.76L44.854 1.258C44.367.474 43.656 0 42.907 0H21.093c-.749 0-1.46.474-1.947 1.257L9 12.761V22h46v-9.24z' /><path d='M41.613 15.931c0-1.605.994-2.93 2.227-2.931H55v18.137C55 33.26 53.68 35 52.05 35h-40.1C10.32 35 9 33.259 9 31.137V13h11.16c1.233 0 2.227 1.323 2.227 2.928v.022c0 1.605 1.005 2.901 2.237 2.901h14.752c1.232 0 2.237-1.308 2.237-2.913v-.007z' fill='#FAFAFA' /></g></g></svg></div><p className='ant-empty-description'>No Data</p></div>}
               </div>

--- a/lib/web/src/components/ConsoleLogs.js
+++ b/lib/web/src/components/ConsoleLogs.js
@@ -28,14 +28,16 @@ const { Option, OptGroup } = Select;
 /* mapStateToProps */
 const mapStateToProps = (state, ownProps) => {
   return Object.assign({}, ownProps, {
-    currentConsoleLogs: state.appReducer.get('currentConsoleLogs')
+    currentConsoleLogs: state.appReducer.get('currentConsoleLogs'),
+    latestOnTop: state.appReducer.get('latestOnTop')
   });
 };
 
 /* mapDispatchToProps */
 const mapDispatchToProps = (dispatch) => ({
   logActions: bindActionCreators(logActions, dispatch),
-  appActions: bindActionCreators(appActions, dispatch)
+  appActions: bindActionCreators(appActions, dispatch),
+  setLatestOnTop: (latestOnTop) => dispatch({ type: 'SET_LATEST_ON_TOP', payload: latestOnTop }) // ✅ New action
 });
 
 class ConsoleLogs extends React.Component {
@@ -68,8 +70,7 @@ class ConsoleLogs extends React.Component {
       errsoleLogQueryTimestamp,
       timezone: timezone || 'Local',
       autoRefresh: false,
-      isAutoRefreshing: false,
-      latestOnTop: false // Default: Old logs on top, latest logs at bottom
+      isAutoRefreshing: false
     };
   }
 
@@ -118,12 +119,13 @@ class ConsoleLogs extends React.Component {
   };
 
   handleToggleLatestOnTop = (checked) => {
+    this.props.setLatestOnTop(checked);
+
     this.setState((prevState) => {
-      const reversedLogs = [...prevState.currentConsoleLogs].reverse(); // Create a new reversed array
-      const uniqueLogs = this.removeDuplicateLogs(reversedLogs); // Ensure no duplicates
+      const reversedLogs = [...prevState.currentConsoleLogs].reverse();
+      const uniqueLogs = this.removeDuplicateLogs(reversedLogs);
 
       return {
-        latestOnTop: checked,
         currentConsoleLogs: uniqueLogs
       };
     });
@@ -360,7 +362,7 @@ class ConsoleLogs extends React.Component {
   }
 
   getCurrentConsoleLogs (query) {
-    const self = this;
+    const { latestOnTop } = this.props; // ✅ Get sort order from Redux
     const logOrder = query.logOrder;
     if (!query.logOrder) delete query.logOrder;
 
@@ -370,7 +372,7 @@ class ConsoleLogs extends React.Component {
 
     this.setState({ consoleLogLoading: true });
 
-    this.props.logActions.getConsoleLogs(query, function (err, data) {
+    this.props.logActions.getConsoleLogs(query, (err, data) => {
       if (!err) {
         try {
           let logs = data.data || [];
@@ -378,21 +380,21 @@ class ConsoleLogs extends React.Component {
 
           if (!filters || Object.keys(filters).length === 0) {
             if (logs.length === 0) {
-              self.notificationMsg('info', 'No logs to load with the applied filters.', '', 3);
+              this.notificationMsg('info', 'No logs to load with the applied filters.', '', 3);
             } else {
-              logs = self.combineLogs(logs, logOrder);
-              logs = self.removeDuplicateLogs(logs); // ✅ Ensure unique logs before setting state
+              logs = this.combineLogs(logs, logOrder);
+              logs = this.removeDuplicateLogs(logs);
 
               logs.sort((a, b) => {
                 const dateA = new Date(a.attributes.timestamp);
                 const dateB = new Date(b.attributes.timestamp);
-                return self.state.latestOnTop ? dateB - dateA : dateA - dateB;
+                return latestOnTop ? dateB - dateA : dateA - dateB;
               });
 
-              self.setState({ currentConsoleLogs: logs });
-              self.props.appActions.addConsoleLogs(logs);
+              this.setState({ currentConsoleLogs: logs });
+              this.props.appActions.addConsoleLogs(logs);
             }
-            self.setState({ oldTimestamp: null, latestTimestamp: null });
+            this.setState({ oldTimestamp: null, latestTimestamp: null });
           }
 
           if (filters && Object.keys(filters).length !== 0) {
@@ -401,28 +403,28 @@ class ConsoleLogs extends React.Component {
             if (logs.length === 0) {
               logs = [{ type: 'logs', attributes: { oldTimestamp, latestTimestamp } }];
             }
-            logs = self.combineLogs(logs, logOrder);
-            logs = self.removeDuplicateLogs(logs); // ✅ Remove duplicates after combining logs
+            logs = this.combineLogs(logs, logOrder);
+            logs = this.removeDuplicateLogs(logs);
 
             logs.sort((a, b) => {
               const dateA = new Date(a.attributes.timestamp);
               const dateB = new Date(b.attributes.timestamp);
-              return self.state.latestOnTop ? dateB - dateA : dateA - dateB;
+              return latestOnTop ? dateB - dateA : dateA - dateB;
             });
 
-            self.setState({ currentConsoleLogs: logs });
-            self.props.appActions.addConsoleLogs(logs);
-            self.setState({ oldTimestamp, latestTimestamp });
+            this.setState({ currentConsoleLogs: logs });
+            this.props.appActions.addConsoleLogs(logs);
+            this.setState({ oldTimestamp, latestTimestamp });
           }
         } catch (e) {
           console.error(e);
-          self.notificationMsg();
+          this.notificationMsg();
         }
       } else {
-        self.notificationMsg();
+        this.notificationMsg();
       }
 
-      self.setState({ consoleLogLoading: false });
+      this.setState({ consoleLogLoading: false });
     });
   }
 
@@ -506,17 +508,12 @@ class ConsoleLogs extends React.Component {
   }
 
   loadMoreErrors (logOrder) {
+    const { latestOnTop } = this.props; // ✅ Get sort order from Redux
     const currentConsoleLogs = this.state.currentConsoleLogs || [];
     let logId, datetime;
     if (logOrder === 'latest') {
       logId = currentConsoleLogs.length > 0 ? currentConsoleLogs[currentConsoleLogs.length - 1].id : null;
-      if (this.state.latestTimestamp) {
-        if (logId) {
-          datetime = currentConsoleLogs[currentConsoleLogs.length - 1].attributes.timestamp;
-        } else {
-          datetime = this.state.latestTimestamp;
-        }
-      }
+      datetime = logId ? currentConsoleLogs[currentConsoleLogs.length - 1].attributes.timestamp : this.state.latestTimestamp;
     } else if (logOrder === 'old') {
       logId = currentConsoleLogs.length > 0 ? currentConsoleLogs[0].id : null;
       datetime = logId ? currentConsoleLogs[0].attributes.timestamp : this.state.oldTimestamp;
@@ -525,9 +522,17 @@ class ConsoleLogs extends React.Component {
     this.getConsoleLogs({ logOrder, logId, datetime }, 'loadMore', (err, newLogs) => {
       if (!err && newLogs.length > 0) {
         this.setState((prevState) => {
-          const mergedLogs = logOrder === 'latest'
-            ? [...prevState.currentConsoleLogs, ...newLogs] // Append latest logs
-            : [...newLogs, ...prevState.currentConsoleLogs]; // Prepend old logs
+          let mergedLogs;
+
+          if (latestOnTop) {
+            mergedLogs = logOrder === 'latest'
+              ? [...newLogs, ...prevState.currentConsoleLogs] // Insert new logs at the top
+              : [...prevState.currentConsoleLogs, ...newLogs]; // Insert old logs at the bottom
+          } else {
+            mergedLogs = logOrder === 'latest'
+              ? [...prevState.currentConsoleLogs, ...newLogs] // Append latest logs at the bottom
+              : [...newLogs, ...prevState.currentConsoleLogs]; // Prepend old logs at the top
+          }
 
           return {
             currentConsoleLogs: this.removeDuplicateLogs(mergedLogs) // ✅ Ensure uniqueness
@@ -999,7 +1004,7 @@ class ConsoleLogs extends React.Component {
                 </p>
                 {currentConsoleLogs.length !== 0 &&
                   <Collapse activeKey={activeKeys} onChange={this.handlePanelChange.bind(this)}>
-                    {this.state.latestOnTop
+                    {this.props.latestOnTop
                       ? (
                         <>
                           <p className='logs_more'>There may be newer logs to load. <a onClick={() => this.loadMoreErrors('latest')}>Load More</a> </p>

--- a/lib/web/src/components/ConsoleLogs.js
+++ b/lib/web/src/components/ConsoleLogs.js
@@ -123,7 +123,7 @@ class ConsoleLogs extends React.Component {
     cookies.set('errsole-latest-on-top', newSortOrder, { path: '/', maxAge: 30 * 24 * 60 * 60 });
     this.setState((prevState) => ({
       latestOnTop: newSortOrder,
-      currentConsoleLogs: [...prevState.currentConsoleLogs].reverse()
+      currentConsoleLogs: this.combineLogs(prevState.currentConsoleLogs, null, newSortOrder)
     }));
   };
 
@@ -378,14 +378,8 @@ class ConsoleLogs extends React.Component {
             if (logs.length === 0) {
               this.notificationMsg('info', 'No logs to load with the applied filters.', '', 3);
             } else {
-              logs = this.combineLogs(logs, logOrder);
+              logs = this.combineLogs(logs, logOrder, latestOnTop);
               logs = this.removeDuplicateLogs(logs);
-
-              logs.sort((a, b) => {
-                const dateA = new Date(a.attributes.timestamp);
-                const dateB = new Date(b.attributes.timestamp);
-                return latestOnTop === 'Newest First' ? dateB - dateA : dateA - dateB;
-              });
 
               this.setState({ currentConsoleLogs: logs });
               this.props.appActions.addConsoleLogs(logs);
@@ -399,15 +393,8 @@ class ConsoleLogs extends React.Component {
             if (logs.length === 0) {
               logs = [{ type: 'logs', attributes: { oldTimestamp, latestTimestamp } }];
             }
-            logs = this.combineLogs(logs, logOrder);
-            console.log('After combineLogs (with filters):', logs);
+            logs = this.combineLogs(logs, logOrder, latestOnTop);
             logs = this.removeDuplicateLogs(logs);
-
-            logs.sort((a, b) => {
-              const dateA = new Date(a.attributes.timestamp);
-              const dateB = new Date(b.attributes.timestamp);
-              return latestOnTop === 'Newest First' ? dateB - dateA : dateA - dateB;
-            });
 
             this.setState({ currentConsoleLogs: logs });
             this.props.appActions.addConsoleLogs(logs);
@@ -467,7 +454,7 @@ class ConsoleLogs extends React.Component {
     return result;
   }
 
-  combineLogs (newLogs, logOrder) {
+  combineLogs (newLogs, logOrder, latestOnTop) {
     let allLogs = [];
 
     if (logOrder === 'latest') {
@@ -481,15 +468,13 @@ class ConsoleLogs extends React.Component {
     allLogs.sort((a, b) => {
       const dateA = new Date(a.attributes.timestamp);
       const dateB = new Date(b.attributes.timestamp);
-
       if (dateA - dateB !== 0) {
         return dateA - dateB;
       }
-
       return a.id.localeCompare(b.id);
     });
 
-    if (this.state.latestOnTop === 'Newest First') {
+    if (latestOnTop === 'Newest First') {
       allLogs.reverse();
     }
 
@@ -526,39 +511,17 @@ class ConsoleLogs extends React.Component {
     const currentConsoleLogs = this.state.currentConsoleLogs || [];
     let logId, datetime;
 
-    if (logOrder === 'latest') {
-      logId = currentConsoleLogs.length > 0 ? currentConsoleLogs[currentConsoleLogs.length - 1].id : null;
-      datetime = logId ? currentConsoleLogs[currentConsoleLogs.length - 1].attributes.timestamp : this.state.latestTimestamp;
-    } else if (logOrder === 'old') {
-      logId = currentConsoleLogs.length > 0 ? currentConsoleLogs[0].id : null;
-      datetime = logId ? currentConsoleLogs[0].attributes.timestamp : this.state.oldTimestamp;
+    if (currentConsoleLogs.length > 0) {
+      if (logOrder === 'latest') {
+        logId = latestOnTop === 'Newest First' ? currentConsoleLogs[0].id : currentConsoleLogs[currentConsoleLogs.length - 1].id;
+        datetime = latestOnTop === 'Newest First' ? currentConsoleLogs[0].attributes.timestamp : currentConsoleLogs[currentConsoleLogs.length - 1].attributes.timestamp;
+      } else if (logOrder === 'old') {
+        logId = latestOnTop === 'Newest First' ? currentConsoleLogs[currentConsoleLogs.length - 1].id : currentConsoleLogs[0].id;
+        datetime = latestOnTop === 'Newest First' ? currentConsoleLogs[currentConsoleLogs.length - 1].attributes.timestamp : currentConsoleLogs[0].attributes.timestamp;
+      }
     }
 
-    this.getConsoleLogs({ logOrder, logId, datetime }, 'loadMore', (err, newLogs) => {
-      if (!err && newLogs.length > 0) {
-        this.setState((prevState) => {
-          const mergedLogs = [...prevState.currentConsoleLogs, ...newLogs];
-
-          mergedLogs.sort((a, b) => {
-            const dateA = new Date(a.attributes.timestamp);
-            const dateB = new Date(b.attributes.timestamp);
-
-            if (dateA - dateB !== 0) {
-              return dateA - dateB;
-            }
-
-            return a.id.localeCompare(b.id);
-          });
-          if (latestOnTop === 'Newest First') {
-            mergedLogs.reverse();
-          }
-
-          return {
-            currentConsoleLogs: this.removeDuplicateLogs(mergedLogs)
-          };
-        });
-      }
-    });
+    this.getConsoleLogs({ logOrder, logId, datetime }, 'loadMore');
   }
 
   sortLogs (latest) {

--- a/lib/web/src/components/ConsoleLogs.js
+++ b/lib/web/src/components/ConsoleLogs.js
@@ -68,7 +68,8 @@ class ConsoleLogs extends React.Component {
       errsoleLogQueryTimestamp,
       timezone: timezone || 'Local',
       autoRefresh: false,
-      isAutoRefreshing: false
+      isAutoRefreshing: false,
+      latestOnTop: false // Default: Old logs on top, latest logs at bottom
     };
   }
 
@@ -114,6 +115,36 @@ class ConsoleLogs extends React.Component {
   stopAutoRefresh = () => {
     clearInterval(this.autoRefreshInterval);
     this.setState({ isAutoRefreshing: false });
+  };
+
+  toggleLatestOnTop = (checked) => {
+    this.setState((prevState) => {
+      const reversedLogs = [...prevState.currentConsoleLogs].reverse(); // Create a new reversed array
+      const uniqueLogs = this.removeDuplicateLogs(reversedLogs); // Ensure no duplicates
+
+      return {
+        latestOnTop: checked,
+        currentConsoleLogs: uniqueLogs
+      };
+    });
+  };
+
+  removeDuplicateLogs (logs) {
+    const uniqueLogs = [];
+    const seen = new Set();
+    logs.forEach((log) => {
+      if (!seen.has(log.id)) {
+        seen.add(log.id);
+        uniqueLogs.push(log);
+      }
+    });
+    return uniqueLogs;
+  }
+
+  sortLogsByToggle = () => {
+    this.setState((prevState) => ({
+      currentConsoleLogs: [...prevState.currentConsoleLogs].reverse()
+    }));
   };
 
   getHostnames () {
@@ -337,62 +368,51 @@ class ConsoleLogs extends React.Component {
       query.lte_timestamp = new Date(new Date(query.lte_timestamp).getTime() + 1000).toISOString();
     }
 
-    this.setState({
-      consoleLogLoading: true
-    });
+    this.setState({ consoleLogLoading: true });
+
     this.props.logActions.getConsoleLogs(query, function (err, data) {
       if (!err) {
         try {
           let logs = data.data || [];
           const filters = data.meta ? data.meta.filters : {};
-          // no search
+
           if (!filters || Object.keys(filters).length === 0) {
             if (logs.length === 0) {
-              self.notificationMsg('info', 'No logs to load with the applied filters. Try adjusting the filters or search terms and search again.', '', 3);
-            } else if (logs.length > 0) {
+              self.notificationMsg('info', 'No logs to load with the applied filters.', '', 3);
+            } else {
               logs = self.combineLogs(logs, logOrder);
-              self.setState({
-                currentConsoleLogs: logs
+              logs = self.removeDuplicateLogs(logs); // ✅ Ensure unique logs before setting state
+
+              logs.sort((a, b) => {
+                const dateA = new Date(a.attributes.timestamp);
+                const dateB = new Date(b.attributes.timestamp);
+                return self.state.latestOnTop ? dateB - dateA : dateA - dateB;
               });
+
+              self.setState({ currentConsoleLogs: logs });
               self.props.appActions.addConsoleLogs(logs);
             }
-            self.setState({
-              oldTimestamp: null,
-              latestTimestamp: null
-            });
+            self.setState({ oldTimestamp: null, latestTimestamp: null });
           }
-          // handle search
+
           if (filters && Object.keys(filters).length !== 0) {
             const oldTimestamp = filters.gte_timestamp;
             const latestTimestamp = filters.lte_timestamp;
             if (logs.length === 0) {
-              logs = [{
-                type: 'logs',
-                attributes: {
-                  oldTimestamp,
-                  latestTimestamp
-                }
-              }];
+              logs = [{ type: 'logs', attributes: { oldTimestamp, latestTimestamp } }];
             }
             logs = self.combineLogs(logs, logOrder);
-            self.setState({
-              currentConsoleLogs: logs
+            logs = self.removeDuplicateLogs(logs); // ✅ Remove duplicates after combining logs
+
+            logs.sort((a, b) => {
+              const dateA = new Date(a.attributes.timestamp);
+              const dateB = new Date(b.attributes.timestamp);
+              return self.state.latestOnTop ? dateB - dateA : dateA - dateB;
             });
+
+            self.setState({ currentConsoleLogs: logs });
             self.props.appActions.addConsoleLogs(logs);
-            if (!logOrder || (!self.state.oldTimestamp && !self.state.latestTimestamp)) {
-              self.setState({
-                oldTimestamp,
-                latestTimestamp
-              });
-            } else if (logOrder === 'old') {
-              self.setState({
-                oldTimestamp
-              });
-            } else if (logOrder === 'latest') {
-              self.setState({
-                latestTimestamp
-              });
-            }
+            self.setState({ oldTimestamp, latestTimestamp });
           }
         } catch (e) {
           console.error(e);
@@ -401,9 +421,8 @@ class ConsoleLogs extends React.Component {
       } else {
         self.notificationMsg();
       }
-      self.setState({
-        consoleLogLoading: false
-      });
+
+      self.setState({ consoleLogLoading: false });
     });
   }
 
@@ -455,6 +474,9 @@ class ConsoleLogs extends React.Component {
     if (logOrder === 'latest') allLogs = oldLogs.concat(newLogs);
     else if (logOrder === 'old') allLogs = newLogs.concat(oldLogs);
     else allLogs = newLogs;
+    if (this.state.latestOnTop) {
+      allLogs.reverse();
+    }
     return allLogs;
   }
 
@@ -497,15 +519,22 @@ class ConsoleLogs extends React.Component {
       }
     } else if (logOrder === 'old') {
       logId = currentConsoleLogs.length > 0 ? currentConsoleLogs[0].id : null;
-      if (this.state.oldTimestamp) {
-        if (logId) {
-          datetime = currentConsoleLogs[0].attributes.timestamp;
-        } else {
-          datetime = this.state.oldTimestamp;
-        }
-      }
+      datetime = logId ? currentConsoleLogs[0].attributes.timestamp : this.state.oldTimestamp;
     }
-    this.getConsoleLogs({ logOrder, logId, datetime }, 'loadMore');
+
+    this.getConsoleLogs({ logOrder, logId, datetime }, 'loadMore', (err, newLogs) => {
+      if (!err && newLogs.length > 0) {
+        this.setState((prevState) => {
+          const mergedLogs = logOrder === 'latest'
+            ? [...prevState.currentConsoleLogs, ...newLogs] // Append latest logs
+            : [...newLogs, ...prevState.currentConsoleLogs]; // Prepend old logs
+
+          return {
+            currentConsoleLogs: this.removeDuplicateLogs(mergedLogs) // ✅ Ensure uniqueness
+          };
+        });
+      }
+    });
   }
 
   sortLogs (latest) {
@@ -932,6 +961,9 @@ class ConsoleLogs extends React.Component {
                     <div className='filter float-r log-btn-reset'>
                       <span className='Timezone'>Timezone <Switch checkedChildren='Local' unCheckedChildren='UTC' checked={timezone === 'Local'} onChange={this.changeTimezone.bind(this)} /></span>
                       <span className='Auto-Refresh'>
+                        Logs Order <Switch checkedChildren='Newest First' unCheckedChildren='Oldest First' checked={this.state.latestOnTop} onChange={(checked) => this.setState({ latestOnTop: checked })} />
+                      </span>
+                      <span className='Auto-Refresh'>
                         Auto Refresh <Switch
                           checkedChildren='On'
                           unCheckedChildren='Off'
@@ -962,9 +994,21 @@ class ConsoleLogs extends React.Component {
                 </p>
                 {currentConsoleLogs.length !== 0 &&
                   <Collapse activeKey={activeKeys} onChange={this.handlePanelChange.bind(this)}>
-                    <p className='logs_more'>There may be older logs to load. <a onClick={this.loadMoreErrors.bind(this, 'old')}>Load More</a> </p>
-                    {renderConsoleLogs()}
-                    <p className='logs_more'>There may be newer logs to load. <a onClick={this.loadMoreErrors.bind(this, 'latest')}>Load More</a> </p>
+                    {this.state.latestOnTop
+                      ? (
+                        <>
+                          <p className='logs_more'>There may be newer logs to load. <a onClick={() => this.loadMoreErrors('latest')}>Load More</a> </p>
+                          {renderConsoleLogs()}
+                          <p className='logs_more'>There may be older logs to load. <a onClick={() => this.loadMoreErrors('old')}>Load More</a> </p>
+                        </>
+                        )
+                      : (
+                        <>
+                          <p className='logs_more'>There may be older logs to load. <a onClick={() => this.loadMoreErrors('old')}>Load More</a> </p>
+                          {renderConsoleLogs()}
+                          <p className='logs_more'>There may be newer logs to load. <a onClick={() => this.loadMoreErrors('latest')}>Load More</a> </p>
+                        </>
+                        )}
                   </Collapse>}
                 {currentConsoleLogs.length === 0 && <div className='ant-empty ant-empty-normal'><div className='ant-empty-image'><svg width='64' height='41' viewBox='0 0 64 41' xmlns='http://www.w3.org/2000/svg'><g transform='translate(0 1)' fill='none' fillRule='evenodd'><ellipse fill='#F5F5F5' cx='32' cy='33' rx='32' ry='7' /><g fillRule='nonzero' stroke='#D9D9D9'><path d='M55 12.76L44.854 1.258C44.367.474 43.656 0 42.907 0H21.093c-.749 0-1.46.474-1.947 1.257L9 12.761V22h46v-9.24z' /><path d='M41.613 15.931c0-1.605.994-2.93 2.227-2.931H55v18.137C55 33.26 53.68 35 52.05 35h-40.1C10.32 35 9 33.259 9 31.137V13h11.16c1.233 0 2.227 1.323 2.227 2.928v.022c0 1.605 1.005 2.901 2.237 2.901h14.752c1.232 0 2.237-1.308 2.237-2.913v-.007z' fill='#FAFAFA' /></g></g></svg></div><p className='ant-empty-description'>No Data</p></div>}
               </div>

--- a/lib/web/src/components/ConsoleLogs.js
+++ b/lib/web/src/components/ConsoleLogs.js
@@ -70,7 +70,7 @@ class ConsoleLogs extends React.Component {
       timezone: timezone || 'Local',
       autoRefresh: false,
       isAutoRefreshing: false,
-      latestOnTop // sort order stored as string: 'Newest First' or 'Oldest First'
+      latestOnTop
     };
   }
 
@@ -117,18 +117,6 @@ class ConsoleLogs extends React.Component {
     clearInterval(this.autoRefreshInterval);
     this.setState({ isAutoRefreshing: false });
   };
-
-  // handleToggleLatestOnTop = (checked) => {
-  //   this.setState((prevState) => {
-  //     const reversedLogs = [...prevState.currentConsoleLogs].reverse(); // Create a new reversed array
-  //     const uniqueLogs = this.removeDuplicateLogs(reversedLogs); // Ensure no duplicates
-
-  //     return {
-  //       latestOnTop: checked,
-  //       currentConsoleLogs: uniqueLogs
-  //     };
-  //   });
-  // };
 
   handleToggleLatestOnTop = (checked) => {
     const newSortOrder = checked ? 'Newest First' : 'Oldest First';
@@ -379,13 +367,11 @@ class ConsoleLogs extends React.Component {
     }
 
     this.setState({ consoleLogLoading: true });
-    console.log('Fetching logs with query:', query);
 
     this.props.logActions.getConsoleLogs(query, (err, data) => {
       if (!err) {
         try {
           let logs = data.data || [];
-          console.log('API returned logs:', logs);
           const filters = data.meta ? data.meta.filters : {};
 
           if (!filters || Object.keys(filters).length === 0) {
@@ -393,16 +379,13 @@ class ConsoleLogs extends React.Component {
               this.notificationMsg('info', 'No logs to load with the applied filters.', '', 3);
             } else {
               logs = this.combineLogs(logs, logOrder);
-              console.log('After combineLogs:', logs);
               logs = this.removeDuplicateLogs(logs);
-              console.log('After removeDuplicateLogs:', logs);
 
               logs.sort((a, b) => {
                 const dateA = new Date(a.attributes.timestamp);
                 const dateB = new Date(b.attributes.timestamp);
                 return latestOnTop === 'Newest First' ? dateB - dateA : dateA - dateB;
               });
-              console.log('After sorting:', logs);
 
               this.setState({ currentConsoleLogs: logs });
               this.props.appActions.addConsoleLogs(logs);
@@ -419,15 +402,12 @@ class ConsoleLogs extends React.Component {
             logs = this.combineLogs(logs, logOrder);
             console.log('After combineLogs (with filters):', logs);
             logs = this.removeDuplicateLogs(logs);
-            console.log('After removeDuplicateLogs (with filters):', logs);
 
             logs.sort((a, b) => {
               const dateA = new Date(a.attributes.timestamp);
               const dateB = new Date(b.attributes.timestamp);
               return latestOnTop === 'Newest First' ? dateB - dateA : dateA - dateB;
             });
-
-            console.log('After sorting (with filters):', logs);
 
             this.setState({ currentConsoleLogs: logs });
             this.props.appActions.addConsoleLogs(logs);
@@ -487,60 +467,32 @@ class ConsoleLogs extends React.Component {
     return result;
   }
 
-  // combineLogs (newLogs, logOrder) {
-  //   let allLogs = [];
-
-  //   if (logOrder === 'latest') {
-  //     allLogs = [...this.state.currentConsoleLogs, ...newLogs]; // Append new logs at the bottom
-  //   } else if (logOrder === 'old') {
-  //     allLogs = [...newLogs, ...this.state.currentConsoleLogs]; // Add new logs at the top
-  //   } else {
-  //     allLogs = newLogs;
-  //   }
-
-  //   // Ensure logs are sorted from oldest to newest (ascending order)
-  //   allLogs.sort((a, b) => {
-  //     return new Date(a.attributes.timestamp) - new Date(b.attributes.timestamp);
-  //   });
-
-  //   // Reverse logs if 'latestOnTop' is true (newest first)
-  //   if (this.state.latestOnTop === 'Newest First') {
-  //     allLogs.reverse();
-  //   }
-
-  //   console.log('Final sorted logs:', allLogs);
-  //   return allLogs;
-  // }
-
   combineLogs (newLogs, logOrder) {
     let allLogs = [];
 
     if (logOrder === 'latest') {
-      allLogs = [...this.state.currentConsoleLogs, ...newLogs]; // Append new logs at the bottom
+      allLogs = [...this.state.currentConsoleLogs, ...newLogs];
     } else if (logOrder === 'old') {
-      allLogs = [...newLogs, ...this.state.currentConsoleLogs]; // Add new logs at the top
+      allLogs = [...newLogs, ...this.state.currentConsoleLogs];
     } else {
       allLogs = newLogs;
     }
 
-    // Sort logs by timestamp (oldest first), then by ID to ensure stable order
     allLogs.sort((a, b) => {
       const dateA = new Date(a.attributes.timestamp);
       const dateB = new Date(b.attributes.timestamp);
 
       if (dateA - dateB !== 0) {
-        return dateA - dateB; // Sort by timestamp first
+        return dateA - dateB;
       }
 
-      return a.id.localeCompare(b.id); // Sort by ID if timestamps are the same
+      return a.id.localeCompare(b.id);
     });
 
-    // Reverse logs if "Newest First" is enabled
     if (this.state.latestOnTop === 'Newest First') {
       allLogs.reverse();
     }
 
-    console.log('Final sorted logs:', allLogs);
     return allLogs;
   }
 
@@ -587,19 +539,16 @@ class ConsoleLogs extends React.Component {
         this.setState((prevState) => {
           const mergedLogs = [...prevState.currentConsoleLogs, ...newLogs];
 
-          // Sort logs by timestamp, then by ID to maintain stable order
           mergedLogs.sort((a, b) => {
             const dateA = new Date(a.attributes.timestamp);
             const dateB = new Date(b.attributes.timestamp);
 
             if (dateA - dateB !== 0) {
-              return dateA - dateB; // Sort by timestamp first
+              return dateA - dateB;
             }
 
-            return a.id.localeCompare(b.id); // Sort by ID if timestamps are identical
+            return a.id.localeCompare(b.id);
           });
-
-          // Reverse logs if "Newest First" is enabled
           if (latestOnTop === 'Newest First') {
             mergedLogs.reverse();
           }

--- a/lib/web/src/components/ConsoleLogs.js
+++ b/lib/web/src/components/ConsoleLogs.js
@@ -28,16 +28,14 @@ const { Option, OptGroup } = Select;
 /* mapStateToProps */
 const mapStateToProps = (state, ownProps) => {
   return Object.assign({}, ownProps, {
-    currentConsoleLogs: state.appReducer.get('currentConsoleLogs'),
-    latestOnTop: state.appReducer.get('latestOnTop')
+    currentConsoleLogs: state.appReducer.get('currentConsoleLogs')
   });
 };
 
 /* mapDispatchToProps */
 const mapDispatchToProps = (dispatch) => ({
   logActions: bindActionCreators(logActions, dispatch),
-  appActions: bindActionCreators(appActions, dispatch),
-  setLatestOnTop: (latestOnTop) => dispatch({ type: 'SET_LATEST_ON_TOP', payload: latestOnTop }) // ✅ New action
+  appActions: bindActionCreators(appActions, dispatch)
 });
 
 class ConsoleLogs extends React.Component {
@@ -45,6 +43,7 @@ class ConsoleLogs extends React.Component {
     super(props);
     document.title = 'Logs | errsole';
     const timezone = cookies.get('errsole-timezone-preference');
+    const latestOnTop = cookies.get('errsole-latest-on-top') || 'Oldest First'; // Default to 'Oldest First'
     const ConsoleLogs = this.props.currentConsoleLogs;
 
     // let search = this.props.location.search;
@@ -69,6 +68,7 @@ class ConsoleLogs extends React.Component {
       errsoleLogQueryId,
       errsoleLogQueryTimestamp,
       timezone: timezone || 'Local',
+      latestOnTop,
       autoRefresh: false,
       isAutoRefreshing: false
     };
@@ -118,17 +118,28 @@ class ConsoleLogs extends React.Component {
     this.setState({ isAutoRefreshing: false });
   };
 
+  // handleToggleLatestOnTop = (checked) => {
+  //   this.props.setLatestOnTop(checked);
+
+  //   this.setState((prevState) => {
+  //     const reversedLogs = [...prevState.currentConsoleLogs].reverse();
+  //     const uniqueLogs = this.removeDuplicateLogs(reversedLogs);
+
+  //     return {
+  //       currentConsoleLogs: uniqueLogs
+  //     };
+  //   });
+  // };
+
   handleToggleLatestOnTop = (checked) => {
-    this.props.setLatestOnTop(checked);
+    const newSortOrder = checked ? 'Newest First' : 'Oldest First'; // ✅ Toggle between 'Newest First' and 'Oldest First'
 
-    this.setState((prevState) => {
-      const reversedLogs = [...prevState.currentConsoleLogs].reverse();
-      const uniqueLogs = this.removeDuplicateLogs(reversedLogs);
+    cookies.set('errsole-latest-on-top', newSortOrder, { path: '/', maxAge: 30 * 24 * 60 * 60 }); // ✅ Store in cookies
 
-      return {
-        currentConsoleLogs: uniqueLogs
-      };
-    });
+    this.setState((prevState) => ({
+      latestOnTop: newSortOrder,
+      currentConsoleLogs: [...prevState.currentConsoleLogs].reverse()
+    }));
   };
 
   removeDuplicateLogs (logs) {
@@ -362,7 +373,7 @@ class ConsoleLogs extends React.Component {
   }
 
   getCurrentConsoleLogs (query) {
-    const { latestOnTop } = this.props; // ✅ Get sort order from Redux
+    const { latestOnTop } = this.state; // ✅ Use local state
     const logOrder = query.logOrder;
     if (!query.logOrder) delete query.logOrder;
 
@@ -388,7 +399,7 @@ class ConsoleLogs extends React.Component {
               logs.sort((a, b) => {
                 const dateA = new Date(a.attributes.timestamp);
                 const dateB = new Date(b.attributes.timestamp);
-                return latestOnTop ? dateB - dateA : dateA - dateB;
+                return latestOnTop === 'Newest First' ? dateB - dateA : dateA - dateB; // ✅ Correct sorting condition
               });
 
               this.setState({ currentConsoleLogs: logs });
@@ -409,7 +420,7 @@ class ConsoleLogs extends React.Component {
             logs.sort((a, b) => {
               const dateA = new Date(a.attributes.timestamp);
               const dateB = new Date(b.attributes.timestamp);
-              return latestOnTop ? dateB - dateA : dateA - dateB;
+              return latestOnTop === 'Newest First' ? dateB - dateA : dateA - dateB; // ✅ Apply correct condition
             });
 
             this.setState({ currentConsoleLogs: logs });
@@ -508,7 +519,7 @@ class ConsoleLogs extends React.Component {
   }
 
   loadMoreErrors (logOrder) {
-    const { latestOnTop } = this.props; // ✅ Get sort order from Redux
+    const { latestOnTop } = this.state; // ✅ Get sort order from state
     const currentConsoleLogs = this.state.currentConsoleLogs || [];
     let logId, datetime;
     if (logOrder === 'latest') {
@@ -524,14 +535,14 @@ class ConsoleLogs extends React.Component {
         this.setState((prevState) => {
           let mergedLogs;
 
-          if (latestOnTop) {
+          if (latestOnTop === 'Newest First') {
             mergedLogs = logOrder === 'latest'
-              ? [...newLogs, ...prevState.currentConsoleLogs] // Insert new logs at the top
-              : [...prevState.currentConsoleLogs, ...newLogs]; // Insert old logs at the bottom
+              ? [...newLogs, ...prevState.currentConsoleLogs] // ✅ Insert latest logs at the top
+              : [...prevState.currentConsoleLogs, ...newLogs]; // ✅ Insert old logs at the bottom
           } else {
             mergedLogs = logOrder === 'latest'
-              ? [...prevState.currentConsoleLogs, ...newLogs] // Append latest logs at the bottom
-              : [...newLogs, ...prevState.currentConsoleLogs]; // Prepend old logs at the top
+              ? [...prevState.currentConsoleLogs, ...newLogs] // ✅ Append latest logs at the bottom
+              : [...newLogs, ...prevState.currentConsoleLogs]; // ✅ Prepend old logs at the top
           }
 
           return {
@@ -969,9 +980,10 @@ class ConsoleLogs extends React.Component {
                         Logs Order <Switch
                           checkedChildren='Newest First'
                           unCheckedChildren='Oldest First'
-                          checked={this.state.latestOnTop}
+                          checked={this.state.latestOnTop === 'Newest First'}
                           onChange={this.handleToggleLatestOnTop}
                                    />
+
                       </span>
                       <span className='Auto-Refresh'>
                         Auto Refresh <Switch
@@ -1004,7 +1016,7 @@ class ConsoleLogs extends React.Component {
                 </p>
                 {currentConsoleLogs.length !== 0 &&
                   <Collapse activeKey={activeKeys} onChange={this.handlePanelChange.bind(this)}>
-                    {this.props.latestOnTop
+                    {this.state.latestOnTop === 'Newest First'
                       ? (
                         <>
                           <p className='logs_more'>There may be newer logs to load. <a onClick={() => this.loadMoreErrors('latest')}>Load More</a> </p>

--- a/lib/web/src/components/ConsoleLogs.js
+++ b/lib/web/src/components/ConsoleLogs.js
@@ -117,7 +117,7 @@ class ConsoleLogs extends React.Component {
     this.setState({ isAutoRefreshing: false });
   };
 
-  toggleLatestOnTop = (checked) => {
+  handleToggleLatestOnTop = (checked) => {
     this.setState((prevState) => {
       const reversedLogs = [...prevState.currentConsoleLogs].reverse(); // Create a new reversed array
       const uniqueLogs = this.removeDuplicateLogs(reversedLogs); // Ensure no duplicates
@@ -961,7 +961,12 @@ class ConsoleLogs extends React.Component {
                     <div className='filter float-r log-btn-reset'>
                       <span className='Timezone'>Timezone <Switch checkedChildren='Local' unCheckedChildren='UTC' checked={timezone === 'Local'} onChange={this.changeTimezone.bind(this)} /></span>
                       <span className='Auto-Refresh'>
-                        Logs Order <Switch checkedChildren='Newest First' unCheckedChildren='Oldest First' checked={this.state.latestOnTop} onChange={(checked) => this.setState({ latestOnTop: checked })} />
+                        Logs Order <Switch
+                          checkedChildren='Newest First'
+                          unCheckedChildren='Oldest First'
+                          checked={this.state.latestOnTop}
+                          onChange={this.handleToggleLatestOnTop}
+                                   />
                       </span>
                       <span className='Auto-Refresh'>
                         Auto Refresh <Switch

--- a/lib/web/src/components/ConsoleLogs.js
+++ b/lib/web/src/components/ConsoleLogs.js
@@ -43,7 +43,7 @@ class ConsoleLogs extends React.Component {
     super(props);
     document.title = 'Logs | errsole';
     const timezone = cookies.get('errsole-timezone-preference');
-    const latestOnTop = cookies.get('errsole-latest-on-top') || 'Oldest First'; // Default to 'Oldest First'
+    const latestOnTop = cookies.get('errsole-latest-on-top') || 'Oldest First';
     const ConsoleLogs = this.props.currentConsoleLogs;
 
     // let search = this.props.location.search;
@@ -68,9 +68,9 @@ class ConsoleLogs extends React.Component {
       errsoleLogQueryId,
       errsoleLogQueryTimestamp,
       timezone: timezone || 'Local',
-      latestOnTop,
       autoRefresh: false,
-      isAutoRefreshing: false
+      isAutoRefreshing: false,
+      latestOnTop // sort order stored as string: 'Newest First' or 'Oldest First'
     };
   }
 
@@ -119,23 +119,20 @@ class ConsoleLogs extends React.Component {
   };
 
   // handleToggleLatestOnTop = (checked) => {
-  //   this.props.setLatestOnTop(checked);
-
   //   this.setState((prevState) => {
-  //     const reversedLogs = [...prevState.currentConsoleLogs].reverse();
-  //     const uniqueLogs = this.removeDuplicateLogs(reversedLogs);
+  //     const reversedLogs = [...prevState.currentConsoleLogs].reverse(); // Create a new reversed array
+  //     const uniqueLogs = this.removeDuplicateLogs(reversedLogs); // Ensure no duplicates
 
   //     return {
+  //       latestOnTop: checked,
   //       currentConsoleLogs: uniqueLogs
   //     };
   //   });
   // };
 
   handleToggleLatestOnTop = (checked) => {
-    const newSortOrder = checked ? 'Newest First' : 'Oldest First'; // ✅ Toggle between 'Newest First' and 'Oldest First'
-
-    cookies.set('errsole-latest-on-top', newSortOrder, { path: '/', maxAge: 30 * 24 * 60 * 60 }); // ✅ Store in cookies
-
+    const newSortOrder = checked ? 'Newest First' : 'Oldest First';
+    cookies.set('errsole-latest-on-top', newSortOrder, { path: '/', maxAge: 30 * 24 * 60 * 60 });
     this.setState((prevState) => ({
       latestOnTop: newSortOrder,
       currentConsoleLogs: [...prevState.currentConsoleLogs].reverse()
@@ -373,7 +370,7 @@ class ConsoleLogs extends React.Component {
   }
 
   getCurrentConsoleLogs (query) {
-    const { latestOnTop } = this.state; // ✅ Use local state
+    const { latestOnTop } = this.state;
     const logOrder = query.logOrder;
     if (!query.logOrder) delete query.logOrder;
 
@@ -382,11 +379,13 @@ class ConsoleLogs extends React.Component {
     }
 
     this.setState({ consoleLogLoading: true });
+    console.log('Fetching logs with query:', query);
 
     this.props.logActions.getConsoleLogs(query, (err, data) => {
       if (!err) {
         try {
           let logs = data.data || [];
+          console.log('API returned logs:', logs);
           const filters = data.meta ? data.meta.filters : {};
 
           if (!filters || Object.keys(filters).length === 0) {
@@ -394,13 +393,16 @@ class ConsoleLogs extends React.Component {
               this.notificationMsg('info', 'No logs to load with the applied filters.', '', 3);
             } else {
               logs = this.combineLogs(logs, logOrder);
+              console.log('After combineLogs:', logs);
               logs = this.removeDuplicateLogs(logs);
+              console.log('After removeDuplicateLogs:', logs);
 
               logs.sort((a, b) => {
                 const dateA = new Date(a.attributes.timestamp);
                 const dateB = new Date(b.attributes.timestamp);
-                return latestOnTop === 'Newest First' ? dateB - dateA : dateA - dateB; // ✅ Correct sorting condition
+                return latestOnTop === 'Newest First' ? dateB - dateA : dateA - dateB;
               });
+              console.log('After sorting:', logs);
 
               this.setState({ currentConsoleLogs: logs });
               this.props.appActions.addConsoleLogs(logs);
@@ -415,13 +417,17 @@ class ConsoleLogs extends React.Component {
               logs = [{ type: 'logs', attributes: { oldTimestamp, latestTimestamp } }];
             }
             logs = this.combineLogs(logs, logOrder);
+            console.log('After combineLogs (with filters):', logs);
             logs = this.removeDuplicateLogs(logs);
+            console.log('After removeDuplicateLogs (with filters):', logs);
 
             logs.sort((a, b) => {
               const dateA = new Date(a.attributes.timestamp);
               const dateB = new Date(b.attributes.timestamp);
-              return latestOnTop === 'Newest First' ? dateB - dateA : dateA - dateB; // ✅ Apply correct condition
+              return latestOnTop === 'Newest First' ? dateB - dateA : dateA - dateB;
             });
+
+            console.log('After sorting (with filters):', logs);
 
             this.setState({ currentConsoleLogs: logs });
             this.props.appActions.addConsoleLogs(logs);
@@ -481,15 +487,60 @@ class ConsoleLogs extends React.Component {
     return result;
   }
 
+  // combineLogs (newLogs, logOrder) {
+  //   let allLogs = [];
+
+  //   if (logOrder === 'latest') {
+  //     allLogs = [...this.state.currentConsoleLogs, ...newLogs]; // Append new logs at the bottom
+  //   } else if (logOrder === 'old') {
+  //     allLogs = [...newLogs, ...this.state.currentConsoleLogs]; // Add new logs at the top
+  //   } else {
+  //     allLogs = newLogs;
+  //   }
+
+  //   // Ensure logs are sorted from oldest to newest (ascending order)
+  //   allLogs.sort((a, b) => {
+  //     return new Date(a.attributes.timestamp) - new Date(b.attributes.timestamp);
+  //   });
+
+  //   // Reverse logs if 'latestOnTop' is true (newest first)
+  //   if (this.state.latestOnTop === 'Newest First') {
+  //     allLogs.reverse();
+  //   }
+
+  //   console.log('Final sorted logs:', allLogs);
+  //   return allLogs;
+  // }
+
   combineLogs (newLogs, logOrder) {
-    const oldLogs = this.state.currentConsoleLogs || [];
-    let allLogs;
-    if (logOrder === 'latest') allLogs = oldLogs.concat(newLogs);
-    else if (logOrder === 'old') allLogs = newLogs.concat(oldLogs);
-    else allLogs = newLogs;
-    if (this.state.latestOnTop) {
+    let allLogs = [];
+
+    if (logOrder === 'latest') {
+      allLogs = [...this.state.currentConsoleLogs, ...newLogs]; // Append new logs at the bottom
+    } else if (logOrder === 'old') {
+      allLogs = [...newLogs, ...this.state.currentConsoleLogs]; // Add new logs at the top
+    } else {
+      allLogs = newLogs;
+    }
+
+    // Sort logs by timestamp (oldest first), then by ID to ensure stable order
+    allLogs.sort((a, b) => {
+      const dateA = new Date(a.attributes.timestamp);
+      const dateB = new Date(b.attributes.timestamp);
+
+      if (dateA - dateB !== 0) {
+        return dateA - dateB; // Sort by timestamp first
+      }
+
+      return a.id.localeCompare(b.id); // Sort by ID if timestamps are the same
+    });
+
+    // Reverse logs if "Newest First" is enabled
+    if (this.state.latestOnTop === 'Newest First') {
       allLogs.reverse();
     }
+
+    console.log('Final sorted logs:', allLogs);
     return allLogs;
   }
 
@@ -519,9 +570,10 @@ class ConsoleLogs extends React.Component {
   }
 
   loadMoreErrors (logOrder) {
-    const { latestOnTop } = this.state; // ✅ Get sort order from state
+    const { latestOnTop } = this.state;
     const currentConsoleLogs = this.state.currentConsoleLogs || [];
     let logId, datetime;
+
     if (logOrder === 'latest') {
       logId = currentConsoleLogs.length > 0 ? currentConsoleLogs[currentConsoleLogs.length - 1].id : null;
       datetime = logId ? currentConsoleLogs[currentConsoleLogs.length - 1].attributes.timestamp : this.state.latestTimestamp;
@@ -533,20 +585,27 @@ class ConsoleLogs extends React.Component {
     this.getConsoleLogs({ logOrder, logId, datetime }, 'loadMore', (err, newLogs) => {
       if (!err && newLogs.length > 0) {
         this.setState((prevState) => {
-          let mergedLogs;
+          const mergedLogs = [...prevState.currentConsoleLogs, ...newLogs];
 
+          // Sort logs by timestamp, then by ID to maintain stable order
+          mergedLogs.sort((a, b) => {
+            const dateA = new Date(a.attributes.timestamp);
+            const dateB = new Date(b.attributes.timestamp);
+
+            if (dateA - dateB !== 0) {
+              return dateA - dateB; // Sort by timestamp first
+            }
+
+            return a.id.localeCompare(b.id); // Sort by ID if timestamps are identical
+          });
+
+          // Reverse logs if "Newest First" is enabled
           if (latestOnTop === 'Newest First') {
-            mergedLogs = logOrder === 'latest'
-              ? [...newLogs, ...prevState.currentConsoleLogs] // ✅ Insert latest logs at the top
-              : [...prevState.currentConsoleLogs, ...newLogs]; // ✅ Insert old logs at the bottom
-          } else {
-            mergedLogs = logOrder === 'latest'
-              ? [...prevState.currentConsoleLogs, ...newLogs] // ✅ Append latest logs at the bottom
-              : [...newLogs, ...prevState.currentConsoleLogs]; // ✅ Prepend old logs at the top
+            mergedLogs.reverse();
           }
 
           return {
-            currentConsoleLogs: this.removeDuplicateLogs(mergedLogs) // ✅ Ensure uniqueness
+            currentConsoleLogs: this.removeDuplicateLogs(mergedLogs)
           };
         });
       }
@@ -983,7 +1042,6 @@ class ConsoleLogs extends React.Component {
                           checked={this.state.latestOnTop === 'Newest First'}
                           onChange={this.handleToggleLatestOnTop}
                                    />
-
                       </span>
                       <span className='Auto-Refresh'>
                         Auto Refresh <Switch

--- a/lib/web/src/components/ConsoleLogs.js
+++ b/lib/web/src/components/ConsoleLogs.js
@@ -968,10 +968,10 @@ class ConsoleLogs extends React.Component {
                   <span className='hide-message'>
                     <div className='filter float-r log-btn-reset divide-container'>
                       <div className='timezone-container'>
-                        <span>Timezone <Switch checkedChildren='Local' unCheckedChildren='UTC' checked={timezone === 'Local'} onChange={this.changeTimezone.bind(this)} /></span>
+                        <span className='Auto-Refresh'>Timezone <Switch checkedChildren='Local' unCheckedChildren='UTC' checked={timezone === 'Local'} onChange={this.changeTimezone.bind(this)} /></span>
                       </div>
                       <div>
-                        <span>
+                        <span className='Auto-Refresh'>
                           Logs Order <Switch
                             className='sort-order-toggle'
                             checkedChildren='Newest First'

--- a/lib/web/src/components/ConsoleLogs.js
+++ b/lib/web/src/components/ConsoleLogs.js
@@ -970,6 +970,17 @@ class ConsoleLogs extends React.Component {
                       <div className='timezone-container'>
                         <span>Timezone <Switch checkedChildren='Local' unCheckedChildren='UTC' checked={timezone === 'Local'} onChange={this.changeTimezone.bind(this)} /></span>
                       </div>
+                      <div>
+                        <span>
+                          Logs Order <Switch
+                            className='sort-order-toggle'
+                            checkedChildren='Newest First'
+                            unCheckedChildren='Oldest First'
+                            checked={this.state.latestOnTop === 'Newest First'}
+                            onChange={this.handleToggleLatestOnTop}
+                                     />
+                        </span>
+                      </div>
                       <div className='autorefresh-container'>
                         <span className='Auto-Refresh'>
                           AutoRefresh <Switch

--- a/lib/web/src/components/DataRetention.js
+++ b/lib/web/src/components/DataRetention.js
@@ -105,7 +105,7 @@ class DataRetention extends React.Component {
 
   render () {
     const logsTTLDays = this.state.logsTTLDays || null;
-    const loadingStatus = this.state.loadingStatus || null;
+    const loadingStatus = this.state.loadingStatus || false;
 
     return (
       <>

--- a/lib/web/src/reducers/appReducer.js
+++ b/lib/web/src/reducers/appReducer.js
@@ -1,7 +1,8 @@
 import Immutable from 'immutable';
 
 const initialState = Immutable.Map({
-  currentConsoleLogs: []
+  currentConsoleLogs: [],
+  latestOnTop: false
 });
 
 function appReducer (state = initialState, action) {
@@ -14,6 +15,9 @@ function appReducer (state = initialState, action) {
     case 'CLEAR_CONSOLE_LOGS': {
       state = state.set('currentConsoleLogs', []);
       break;
+    }
+    case 'SET_LATEST_ON_TOP': {
+      return state.set('latestOnTop', action.payload);
     }
     case 'RESET_USER_STATE': {
       state = initialState;


### PR DESCRIPTION
This PR introduces a toggle switch that allows users to dynamically change the sort order of logs. When the switch is ON, logs are displayed in descending order (newest first). When OFF, logs are shown in ascending order (oldest first).

Changes
- Implemented a toggle switch in the UI to control log sorting.
- Updated the log retrieval logic to apply sorting based on the toggle state.
- Ensured the toggle state is persisted and properly reflected when switching views.
- -Provided support for a responsive mobile view of the toggle.

Impact
- Provides flexibility for users to view logs in their preferred order.
- Enhances usability by allowing quick access to recent logs when needed.

Testing

- Verified that switching ON displays logs in descending order.
- Verified that switching OFF displays logs in ascending order.
- Ensured state updates correctly across sessions.