### PR TITLE
 Pass lteTimestamp/gteTimestamp Along with ltId/gtId in Log Retrieval

### DIFF
--- a/lib/web/src/components/ConsoleCombinedLogs.js
+++ b/lib/web/src/components/ConsoleCombinedLogs.js
@@ -182,7 +182,6 @@ class ConsoleCombinedLogs extends React.Component {
     const combinedLogs = this.state.combinedLogs || [];
     let logId;
 
-    // ✅ Read latestOnTop directly from the cookie
     const latestOnTopFromCookie = cookies.get('errsole-latest-on-top') || 'Oldest First';
 
     if (latestOnTopFromCookie === 'Newest First') {

--- a/lib/web/src/components/ConsoleCombinedLogs.js
+++ b/lib/web/src/components/ConsoleCombinedLogs.js
@@ -81,9 +81,11 @@ class ConsoleCombinedLogs extends React.Component {
       if (queryRequest && queryRequest.logId) {
         if (queryRequest.logOrder === 'old') {
           query.lt_id = queryRequest.logId;
+          query.lte_timestamp = queryRequest.datetime ? new Date(queryRequest.datetime).toISOString() : null;
         }
         if (queryRequest.logOrder === 'latest') {
           query.gt_id = queryRequest.logId;
+          query.gte_timestamp = queryRequest.datetime ? new Date(queryRequest.datetime).toISOString() : null;
         }
       }
 
@@ -180,18 +182,22 @@ class ConsoleCombinedLogs extends React.Component {
 
   loadMoreErrors (logOrder) {
     const combinedLogs = this.state.combinedLogs || [];
-    let logId;
+    let logId, datetime;
 
     const latestOnTopFromCookie = cookies.get('errsole-latest-on-top') || 'Oldest First';
 
-    if (latestOnTopFromCookie === 'Newest First') {
-      logId = logOrder === 'latest' ? combinedLogs[0]?.id : combinedLogs[combinedLogs.length - 1]?.id;
-    } else {
-      logId = logOrder === 'latest' ? combinedLogs[combinedLogs.length - 1]?.id : combinedLogs[0]?.id;
+    if (combinedLogs.length > 0) {
+      if (logOrder === 'latest') {
+        logId = latestOnTopFromCookie === 'Newest First' ? combinedLogs[0].id : combinedLogs[combinedLogs.length - 1].id;
+        datetime = latestOnTopFromCookie === 'Newest First' ? combinedLogs[0].attributes.timestamp : combinedLogs[combinedLogs.length - 1].attributes.timestamp;
+      } else if (logOrder === 'old') {
+        logId = latestOnTopFromCookie === 'Newest First' ? combinedLogs[combinedLogs.length - 1].id : combinedLogs[0].id;
+        datetime = latestOnTopFromCookie === 'Newest First' ? combinedLogs[combinedLogs.length - 1].attributes.timestamp : combinedLogs[0].attributes.timestamp;
+      }
     }
 
     if (logId) {
-      this.getConsoleCombinedLogs({ logOrder, logId });
+      this.getConsoleCombinedLogs({ logOrder, logId, datetime });
     }
   }
 

--- a/lib/web/src/components/ConsoleLogs.js
+++ b/lib/web/src/components/ConsoleLogs.js
@@ -274,9 +274,11 @@ class ConsoleLogs extends React.Component {
     if (queryRequest && queryRequest.logId) {
       if (queryRequest.logOrder === 'old') {
         query.lt_id = queryRequest.logId;
+        query.lte_timestamp = queryRequest.datetime ? new Date(queryRequest.datetime).toISOString() : null;
       }
       if (queryRequest.logOrder === 'latest') {
         query.gt_id = queryRequest.logId;
+        query.gte_timestamp = queryRequest.datetime ? new Date(queryRequest.datetime).toISOString() : null;
       }
     }
     // search time


### PR DESCRIPTION
Currently, the getLogs and searchLogs APIs pass only ltId/gtId when loading the next and previous logs in the storage module. To improve log retrieval efficiency, this PR ensures lteTimestamp/gteTimestamp is also passed along with ltId/gtId.