### PR TITLE
feat: show Cancel Request button on slow responses

### DIFF
--- a/lib/web/src/actions/logActions.js
+++ b/lib/web/src/actions/logActions.js
@@ -1,9 +1,9 @@
 import { http } from 'app/services/httpServices';
 import { Notifications } from 'services/notifications';
 
-export function getConsoleLogs (query, callback) {
+export function getConsoleLogs (query, options = {}, callback) {
   return (dispatch) => {
-    http.getConsoleLogs(query)
+    http.getConsoleLogs(query, options)
       .then((response) => {
         const consoleLogsData = response.data;
         callback(null, consoleLogsData);

--- a/lib/web/src/actions/logActions.js
+++ b/lib/web/src/actions/logActions.js
@@ -5,6 +5,9 @@ export function getConsoleLogs (query, options = {}, callback) {
   return (dispatch) => {
     http.getConsoleLogs(query, options)
       .then((response) => {
+        if (options.signal?.aborted) {
+          return;
+        }
         const consoleLogsData = response.data;
         callback(null, consoleLogsData);
       })

--- a/lib/web/src/components/ConsoleLogs.js
+++ b/lib/web/src/components/ConsoleLogs.js
@@ -71,7 +71,9 @@ class ConsoleLogs extends React.Component {
       timezone: timezone || 'Local',
       autoRefresh: false,
       isAutoRefreshing: false,
-      latestOnTop
+      latestOnTop,
+      showCancelButton: false,
+      abortController: new AbortController()
     };
   }
 
@@ -105,6 +107,17 @@ class ConsoleLogs extends React.Component {
     } else {
       this.stopAutoRefresh();
     }
+  };
+
+  handleCancelRequest = () => {
+    if (this.state.abortController) {
+      this.state.abortController.abort();
+    }
+    this.setState({
+      consoleLogLoading: false,
+      showCancelButton: false,
+      abortController: null
+    });
   };
 
   startAutoRefresh = () => {
@@ -252,6 +265,7 @@ class ConsoleLogs extends React.Component {
   }
 
   getConsoleLogs (queryRequest, callType) {
+    this.setState({ consoleLogLoading: true, showCancelButton: false });
     let query = {};
     // make sure logsType exist
     let logsType = this.state.logsType;
@@ -356,8 +370,34 @@ class ConsoleLogs extends React.Component {
     } else {
       this.setState({ consoleLogLoading: true });
     }
-    // http req
-    this.getCurrentConsoleLogs(query);
+
+    const abortController = new AbortController();
+    this.setState({ abortController });
+
+    const cancelTimeout = setTimeout(() => {
+      this.setState({ showCancelButton: true });
+    }, 10000);
+
+    this.props.logActions.getConsoleLogs(
+      query,
+      { signal: abortController.signal },
+      (err, data) => {
+        clearTimeout(cancelTimeout);
+        if (err) {
+          if (err.name === 'AbortError') {
+            this.notificationMsg('warning', 'Request cancelled by user.');
+          } else {
+            this.notificationMsg();
+          }
+        } else {
+          let logs = data.data || [];
+          logs = this.removeDuplicateLogs(logs);
+          this.setState({ currentConsoleLogs: logs });
+        }
+
+        this.setState({ consoleLogLoading: false, showCancelButton: false, abortController: null });
+      }
+    );
   }
 
   getCurrentConsoleLogs (query) {
@@ -1039,6 +1079,24 @@ class ConsoleLogs extends React.Component {
             </div>
           </Content>
         </Spin>
+        <div style={{ textAlign: 'center' }}>
+          {consoleLogLoading && (
+            <>
+              {this.state.showCancelButton && (
+                <div>
+                  <p>Search can be faster with relevant filters.</p>
+                  <Button
+                    type='primary' danger
+                    onClick={this.handleCancelRequest}
+                    style={{ cursor: 'pointer', padding: '8px 16px' }}
+                  >
+                    Cancel Request
+                  </Button>
+                </div>
+              )}
+            </>
+          )}
+        </div>
         <Modal className='view-logs-modal' width='90%' centered closable maskClosable footer={null} visible={combinedLogsModalStatus} onCancel={this.closeCombinedLogsModal.bind(this, null)} destroyOnClose>
           <ConsoleCombinedLogs errorLogTimestamp={errorLogTimestamp} errorLogId={errorLogId} errorLogHostname={errorLogHostname} />
         </Modal>

--- a/lib/web/src/components/ConsoleLogs.js
+++ b/lib/web/src/components/ConsoleLogs.js
@@ -1084,7 +1084,7 @@ class ConsoleLogs extends React.Component {
             <>
               {this.state.showCancelButton && (
                 <div>
-                  <p>Search can be faster with relevant filters.</p>
+                  <p>Apply relevant filters to load logs faster.</p>
                   <Button
                     type='primary' danger
                     onClick={this.handleCancelRequest}


### PR DESCRIPTION
Added a Cancel Request button that appears if the API response takes more than 10 seconds. This lets users stop the request to avoid long waiting times and unnecessary loading.