### PR TITLE
fix: display "No logs found" message on search when no results

### DIFF
--- a/lib/web/src/components/ConsoleLogs.js
+++ b/lib/web/src/components/ConsoleLogs.js
@@ -145,8 +145,12 @@ class ConsoleLogs extends React.Component {
     const uniqueLogs = [];
     const seen = new Set();
     logs.forEach((log) => {
-      if (!seen.has(log.id)) {
-        seen.add(log.id);
+      if (log.id) {
+        if (!seen.has(log.id)) {
+          seen.add(log.id);
+          uniqueLogs.push(log);
+        }
+      } else {
         uniqueLogs.push(log);
       }
     });


### PR DESCRIPTION
This PR fixes an issue where the "No logs found" message was not being displayed when search results return empty.