### PR TITLE
fix: move View Meta button out of the dropdown

### DIFF
--- a/lib/web/src/components/ConsoleLogs.js
+++ b/lib/web/src/components/ConsoleLogs.js
@@ -16,9 +16,9 @@ import * as logActions from 'actions/logActions.js';
 import * as appActions from 'actions/appActions.js';
 
 /* Ante UI */
-import { DatePicker, Layout, Button, Collapse, Select, Spin, Switch, Modal, Tooltip, Menu, Dropdown, notification, message, ConfigProvider } from 'antd';
+import { DatePicker, Layout, Button, Collapse, Select, Spin, Switch, Modal, Tooltip, notification, message, ConfigProvider } from 'antd';
 
-import { LoadingOutlined, MoreOutlined, RightOutlined, DownOutlined, InfoCircleOutlined } from '@ant-design/icons';
+import { LoadingOutlined, RightOutlined, DownOutlined, InfoCircleOutlined } from '@ant-design/icons';
 
 const cookies = new Cookies();
 
@@ -922,15 +922,7 @@ class ConsoleLogs extends React.Component {
           header = <p className={(source === 'errsole' && 'log_panel_header panel-details') || (source === 'console' && 'log_panel_header panel-details-no-meta')}><span className='log_timestamp'>{occurredAtFormated}</span><span className='log_message_top'>{message}</span></p>;
         }
 
-        const menu = (
-          <Menu>
-            <Menu.Item key='1' onClick={this.openLogMetaModal.bind(this, logId, meta)}>
-              View Meta
-            </Menu.Item>
-          </Menu>
-        );
-
-        const panel = <Panel className='log_panel' header={header} key={logId} extra={<span className='view-log-extra' onClick={event => { event.stopPropagation(); }}><Tooltip placement='topRight' title='View surrounding logs on the host'><Button onClick={this.openCombinedLogsModal.bind(this, occurredAt, logId, hostname)} type='primary'>View Logs</Button></Tooltip>{source === 'errsole' && <Dropdown overlay={menu} className='view-log-details'><Button type='primary'><MoreOutlined /></Button></Dropdown>}</span>}><pre className='log_message_detail'>{message}</pre><p className='log-details'><b>Hostname: </b>{hostname} &nbsp;&nbsp;|&nbsp;&nbsp; <b>PID: </b>{pid} &nbsp;&nbsp;|&nbsp;&nbsp; <b>Source: </b>{source} &nbsp;&nbsp;|&nbsp;&nbsp; <b>Level: </b>{level}</p></Panel>;
+        const panel = <Panel className='log_panel' header={header} key={logId} extra={<span className='view-log-extra' onClick={event => { event.stopPropagation(); }}>{source === 'errsole' && <Tooltip placement='topRight'><Button onClick={this.openLogMetaModal.bind(this, logId, meta)} type='primary'>View Meta</Button></Tooltip>} <Tooltip placement='topRight' title='View surrounding logs on the host'> <Button onClick={this.openCombinedLogsModal.bind(this, occurredAt, logId, hostname)} type='primary'>View Logs</Button></Tooltip></span>}><pre className='log_message_detail'>{message}</pre><p className='log-details'><b>Hostname: </b>{hostname} &nbsp;&nbsp;|&nbsp;&nbsp; <b>PID: </b>{pid} &nbsp;&nbsp;|&nbsp;&nbsp; <b>Source: </b>{source} &nbsp;&nbsp;|&nbsp;&nbsp; <b>Level: </b>{level}</p></Panel>;
 
         return panel;
       });


### PR DESCRIPTION
**Pull Request Description:**

This PR updates the log panel UI by moving the View Meta button out of the dropdown and placing it directly next to the View Logs button.

**🛠 Fixes:**

- Improves accessibility and discoverability of the View Meta action.
- Avoids extra clicks for users by placing both actions clearly in view.
- Makes UI behavior more consistent, especially when the dropdown contains only a single option.